### PR TITLE
pdf, html, and maven links were incorrect

### DIFF
--- a/transactions/1.3/_index.md
+++ b/transactions/1.3/_index.md
@@ -5,12 +5,12 @@ summary: "First release for Jakarta EE 8"
 ---
 Jakarta Transactions
 
-* [Jakarta Transactions 1.3 Specification Document](./transactions-spec-1.3.3.pdf) (PDF)
-* [Jakarta Transactions 1.3 Specification Document](./transactions-spec-1.3.3.html) (HTML)
+* [Jakarta Transactions 1.3 Specification Document](./transactions-spec-1.3.pdf) (PDF)
+* [Jakarta Transactions 1.3 Specification Document](./transactions-spec-1.3.html) (HTML)
 * [Jakarta Transactions 1.3 Javadoc](./apidocs)
 * [Jakarta Transactions 1.3 TCK](https://download.eclipse.org/jakartaee/transactions/1.3/eclipse-transactions-tck-1.3.0.zip)
 * Maven coordinates
-  * [jakarta.transaction:jakarta.transaction-api:jar:1.3.4](https://search.maven.org/artifact/jakarta.transaction/jakarta.transaction-api/1.3.3/jar)
+  * [jakarta.transaction:jakarta.transaction-api:jar:1.3.3](https://search.maven.org/artifact/jakarta.transaction/jakarta.transaction-api/1.3.3/jar)
 
 # Ballots
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

More inconsistencies with Transactions _index.md.  The pdf and html file names were incorrect.  And, the text link for the maven coordinates had the wrong version.