### PR TITLE
Update TCK urls to jakarta branded files. Add "(sig, sha, pub)" links.

### DIFF
--- a/annotations/1.3/_index.md
+++ b/annotations/1.3/_index.md
@@ -9,7 +9,7 @@ enable a declarative style of programming that applies across a variety of Java 
 * [Jakarta Annotations 1.3 Specification Document](./annotations-spec-1.3.pdf) (PDF)
 * [Jakarta Annotations 1.3 Specification Document](./annotations-spec-1.3.html) (HTML)
 * [Jakarta Annotations 1.3 Javadoc](./apidocs)
-* [Jakarta Annotations 1.3 TCK](https://download.eclipse.org/jakartaee/annotations/1.3/eclipse-annotations-tck-1.3.0.zip)
+* [Jakarta Annotations 1.3 TCK](https://download.eclipse.org/jakartaee/annotations/1.3/jakarta-annotations-tck-1.3.0.zip) ([sig](https://download.eclipse.org/jakartaee/annotations/1.3/jakarta-annotations-tck-1.3.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/annotations/1.3/jakarta-annotations-tck-1.3.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.annotation:jakarta.annotation-api:jar:1.3.5](https://search.maven.org/artifact/jakarta.annotation/jakarta.annotation-api/1.3.5/jar)
 

--- a/authentication/1.1/_index.md
+++ b/authentication/1.1/_index.md
@@ -13,7 +13,7 @@ Jakarta Authentication consists of several profiles, with each profile telling h
 * [Jakarta Authentication 1.1 Specification Document](./authentication-spec-1.1.pdf) (PDF)
 * [Jakarta Authentication 1.1 Specification Document](./authentication-spec-1.1.html) (HTML)
 * [Jakarta Authentication 1.1 Javadoc](./apidocs)
-* [Jakarta Authentication 1.1 TCK](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip)
+* [Jakarta Authentication 1.1 TCK](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.security.auth.message:jakarta.security.auth.message-api:jar:1.1.3](https://search.maven.org/artifact/jakarta.security.auth.message/jakarta.security.auth.message-api/1.1.3/jar)
 

--- a/authorization/1.5/_index.md
+++ b/authorization/1.5/_index.md
@@ -11,7 +11,7 @@ these permissions.
 * [Jakarta Authorization 1.5 Specification Document](./authorization-spec-1.5.pdf) (PDF)
 * [Jakarta Authorization 1.5 Specification Document](./authorization-spec-1.5.html) (HTML)
 * [Jakarta Authorization 1.5 Javadoc](./apidocs)
-* [Jakarta Authorization 1.5 TCK](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip)
+* [Jakarta Authorization 1.5 TCK](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip) ([sig](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.authorization:jakarta.authorization-api:jar:1.5.0](https://search.maven.org/artifact/jakarta.authorization/jakarta.authorization-api/1.5.0/jar)
 

--- a/batch/1.0/_index.md
+++ b/batch/1.0/_index.md
@@ -8,7 +8,7 @@ Jakarta Batch specifies a Java API plus an XML-based job specification language 
 * [Jakarta Batch 1.0 Specification Document](./batch-spec-1.0.pdf) (PDF)
 * [Jakarta Batch 1.0 Specification Document](./batch-spec-1.0.html) (HTML)
 * [Jakarta Batch 1.0 Javadoc](./apidocs)
-* [Jakarta Batch 1.0 TCK](https://download.eclipse.org/jakartaee/batch/1.0/jakarta.batch.official.tck-1.0.2.zip)
+* [Jakarta Batch 1.0 TCK](https://download.eclipse.org/jakartaee/batch/1.0/jakarta.batch.official.tck-1.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/batch/1.0/jakarta.batch.official.tck-1.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/batch/1.0/jakarta.batch.official.tck-1.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.batch:jakarta.batch-api:jar:1.0.2](https://search.maven.org/artifact/jakarta.batch/jakarta.batch-api/1.0.2/jar)
 

--- a/bean-validation/2.0/_index.md
+++ b/bean-validation/2.0/_index.md
@@ -8,7 +8,7 @@ Jakarta Bean Validation defines a metadata model and API for JavaBean and method
 * [Jakarta Bean Validation 2.0 Specification Document](./bean-validation_2.0.pdf) (PDF)
 * [Jakarta Bean Validation 2.0 Specification Document](./bean-validation_2.0.html) (HTML)
 * [Jakarta Bean Validation 2.0 Javadoc](./apidocs)
-* [Jakarta Bean Validation 2.0 TCK](http://download.eclipse.org/jakartaee/bean-validation/2.0/beanvalidation-tck-dist-2.0.5.zip)
+* [Jakarta Bean Validation 2.0 TCK](https://download.eclipse.org/jakartaee/bean-validation/2.0/beanvalidation-tck-dist-2.0.5.zip) ([sig](https://download.eclipse.org/jakartaee/bean-validation/2.0/beanvalidation-tck-dist-2.0.5.zip.sig),[sha](https://download.eclipse.org/jakartaee/bean-validation/2.0/beanvalidation-tck-dist-2.0.5.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.validation:jakarta.validation-api:jar:2.0.2](https://search.maven.org/artifact/jakarta.validation/jakarta.validation-api/2.0.2/jar)
 

--- a/cdi/2.0/_index.md
+++ b/cdi/2.0/_index.md
@@ -9,7 +9,7 @@ Jakarta Contexts Dependency Injection specifies a means for obtaining objects in
 * [Jakarta Contexts Dependency Injection 2.0 Specification Document](./cdi-spec-2.0.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 2.0 Specification Document](./cdi-spec-2.0.html) (HTML)
 * [Jakarta Contexts Dependency Injection 2.0 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 2.0 TCK](https://download.eclipse.org/jakartaee/cdi/2.0/cdi-tck-2.0.6-dist.zip)
+* [Jakarta Contexts Dependency Injection 2.0 TCK](https://download.eclipse.org/jakartaee/cdi/2.0/cdi-tck-2.0.6-dist.zip) ([sig](https://download.eclipse.org/jakartaee/cdi/2.0/cdi-tck-2.0.6-dist.zip.sig),[sha](https://download.eclipse.org/jakartaee/cdi/2.0/cdi-tck-2.0.6-dist.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.enterprise:jakarta.enterprise.cdi-api:jar:2.0.2](https://search.maven.org/artifact/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.2/jar)
 

--- a/concurrency/1.1/_index.md
+++ b/concurrency/1.1/_index.md
@@ -8,7 +8,7 @@ Jakarta Concurrency provides a specification for using concurrency from applicat
 * [Jakarta Concurrency 1.1 Specification Document](./concurrency-spec-1.1.pdf) (PDF)
 * [Jakarta Concurrency 1.1 Specification Document](./concurrency-spec-1.1.html) (HTML)
 * [Jakarta Concurrency 1.1 Javadoc](./apidocs)
-* [Jakarta Concurrency 1.1 TCK](https://download.eclipse.org/jakartaee/concurrency/1.1/eclipse-concurrency-tck-1.1.0.zip)
+* [Jakarta Concurrency 1.1 TCK](https://download.eclipse.org/jakartaee/concurrency/1.1/jakarta-concurrency-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/concurrency/1.1/jakarta-concurrency-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/concurrency/1.1/jakarta-concurrency-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:jar:1.1.2](https://search.maven.org/artifact/jakarta.enterprise.concurrent/jakarta.enterprise.concurrent-api/1.1.2/jar)
 

--- a/connectors/1.7/_index.md
+++ b/connectors/1.7/_index.md
@@ -8,7 +8,7 @@ The Jakarta Connectors specification defines a standard architecture for Jakarta
 * [Jakarta Connectors 1.7 Specification Document](./connectors-spec-1.7.pdf) (PDF)
 * [Jakarta Connectors 1.7 Specification Document](./connectors-spec-1.7.html) (HTML)
 * [Jakarta Connectors 1.7 Javadoc](./apidocs)
-* [Jakarta Connectors 1.7 TCK](https://download.eclipse.org/jakartaee/connectors/1.7/connectors-tck-1.7.4.zip)
+* [Jakarta Connectors 1.7 TCK](https://download.eclipse.org/jakartaee/connectors/1.7/connectors-tck-1.7.4.zip) ([sig](https://download.eclipse.org/jakartaee/connectors/1.7/connectors-tck-1.7.4.zip.sig),[sha](https://download.eclipse.org/jakartaee/connectors/1.7/connectors-tck-1.7.4.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.resource:jakarta.resource-api:jar:1.7.4](https://search.maven.org/artifact/jakarta.resource/jakarta.resource-api/1.7.4/jar)
 

--- a/debugging/1.0/_index.md
+++ b/debugging/1.0/_index.md
@@ -10,7 +10,7 @@ the original source (for example, source file and line number references).
 
 * [Jakarta Debugging Support for Other Languages 1.0 Specification Document](./debugging_1.0.pdf) (PDF)
 * [Jakarta Debugging Support for Other Languages 1.0 Specification Document](./debugging_1.0.html) (HTML)
-* [Jakarta Debugging Support for Other Languages TCK](https://download.eclipse.org/jakartaee/debugging/1.0/eclipse-debugging-tck-1.0.0.zip)
+* [Jakarta Debugging Support for Other Languages TCK](https://download.eclipse.org/jakartaee/debugging/1.0/jakarta-debugging-tck-1.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/debugging/1.0/jakarta-debugging-tck-1.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/debugging/1.0/jakarta-debugging-tck-1.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 
 # Ballots
 

--- a/dependency-injection/1.0/_index.md
+++ b/dependency-injection/1.0/_index.md
@@ -9,7 +9,7 @@ Jakarta Dependency Injection specifies a means for obtaining objects in such a w
 * [Jakarta Dependency Injection 1.0 Specification Document](./injection-spec-1.0.pdf) (PDF)
 * [Jakarta Dependency Injection 1.0 Specification Document](./injection-spec-1.0.html) (HTML)
 * [Jakarta Dependency Injection 1.0 Javadoc](./apidocs)
-* [Jakarta Dependency Injection 1.0 TCK](https://download.eclipse.org/jakartaee/dependency-injection/1.0/jakarta.inject-tck-1.0-bin.zip)
+* [Jakarta Dependency Injection 1.0 TCK](https://download.eclipse.org/jakartaee/dependency-injection/1.0/jakarta.inject-tck-1.0-bin.zip) ([sig](https://download.eclipse.org/jakartaee/dependency-injection/1.0/jakarta.inject-tck-1.0-bin.zip.sig),[sha](https://download.eclipse.org/jakartaee/dependency-injection/1.0/jakarta.inject-tck-1.0-bin.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.inject:jakarta.inject-api:jar:1.0](https://search.maven.org/artifact/jakarta.inject/jakarta.inject-api/1.0/jar)
 

--- a/expression-language/3.0/_index.md
+++ b/expression-language/3.0/_index.md
@@ -8,7 +8,7 @@ Jakarta Expression Language defines an expression language for Java applications
 * [Jakarta Expression Language 3.0 Specification Document](./expression-language-spec-3.0.pdf) (PDF)
 * [Jakarta Expression Language 3.0 Specification Document](./expression-language-spec-3.0.html) (HTML)
 * [Jakarta Expression Language 3.0 Javadoc](./apidocs)
-* [Jakarta Expression Language 3.0 TCK](https://download.eclipse.org/jakartaee/expression-language/3.0/jakarta-expression-language-tck-3.0.0.zip)
+* [Jakarta Expression Language 3.0 TCK](https://download.eclipse.org/jakartaee/expression-language/3.0/jakarta-expression-language-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/expression-language/3.0/jakarta-expression-language-tck-3.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/expression-language/3.0/jakarta-expression-language-tck-3.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.el:jakarta.el-api:jar:3.0.3](https://search.maven.org/artifact/jakarta.el/jakarta.el-api/3.0.3/jar)
 

--- a/faces/2.3/_index.md
+++ b/faces/2.3/_index.md
@@ -13,7 +13,7 @@ support for internationalization and accessibility.
 * [Jakarta Server Faces 2.3 Jsdoc](./jsdoc)
 * [Jakarta Server Faces 2.3 Renderkitdoc](./renderkitdoc)
 * [Jakarta Server Faces 2.3 VDLDoc](./vdldoc)
-* [Jakarta Server Faces 2.3 TCK](https://download.eclipse.org/jakartaee/faces/2.3/jakarta-faces-tck-2.3.0.zip)
+* [Jakarta Server Faces 2.3 TCK](https://download.eclipse.org/jakartaee/faces/2.3/jakarta-faces-tck-2.3.0.zip) ([sig](https://download.eclipse.org/jakartaee/faces/2.3/jakarta-faces-tck-2.3.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/faces/2.3/jakarta-faces-tck-2.3.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.faces:jakarta.faces-api:jar:2.3.2](https://search.maven.org/artifact/jakarta.faces/jakarta.faces-api/2.3.2/jar)
 

--- a/interceptors/1.2/_index.md
+++ b/interceptors/1.2/_index.md
@@ -10,7 +10,7 @@ and other managed classes.
 * [Jakarta Interceptors 1.2 Specification Document](./interceptors-spec-1.2.pdf) (PDF)
 * [Jakarta Interceptors 1.2 Specification Document](./interceptors-spec-1.2.html) (HTML)
 * [Jakarta Interceptors 1.2 Javadoc](./apidocs)
-* [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8.0/eclipse-jakartaeetck-8.0.0.zip)
+* [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8.0/jakarta-jakartaeetck-8.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8.0/jakarta-jakartaeetck-8.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8.0/jakarta-jakartaeetck-8.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.interceptor:jakarta.interceptor-api:jar:1.2.5](https://search.maven.org/artifact/jakarta.interceptor/jakarta.interceptor-api/1.2.5/jar)
 

--- a/jsonb/1.0/_index.md
+++ b/jsonb/1.0/_index.md
@@ -8,7 +8,7 @@ Jakarta JSON Binding defines a binding framework for converting Java(R) objects 
 * [Jakarta JSON Binding 1.0 Specification Document](./jsonb-spec-1.0.pdf) (PDF)
 * [Jakarta JSON Binding 1.0 Specification Document](./jsonb-spec-1.0.html) (HTML)
 * [Jakarta JSON Binding 1.0 Javadoc](./apidocs)
-* [Jakarta JSON Binding 1.0 TCK](http://download.eclipse.org/jakartaee/jsonb/1.0/eclipse-jsonb-tck-1.0.0.zip)
+* [Jakarta JSON Binding 1.0 TCK](https://download.eclipse.org/jakartaee/jsonb/1.0/jakarta-jsonb-tck-1.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/1.0/jakarta-jsonb-tck-1.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/jsonb/1.0/jakarta-jsonb-tck-1.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.json.bind:jakarta.json.bind-api:jar:1.0.2](https://search.maven.org/artifact/jakarta.json.bind/jakarta.json.bind-api/1.0.2/jar)
 

--- a/jsonp/1.1/_index.md
+++ b/jsonp/1.1/_index.md
@@ -9,7 +9,7 @@ querying JSON documents.
 * [Jakarta JSON Processing 1.1 Specification Document](./jsonp-spec-1.1.pdf) (PDF)
 * [Jakarta JSON Processing 1.1 Specification Document](./jsonp-spec-1.1.html) (HTML)
 * [Jakarta JSON Processing 1.1 Javadoc](./apidocs)
-* [Jakarta JSON Processing 1.1 TCK](http://download.eclipse.org/jakartaee/jsonp/1.1/eclipse-jsonp-tck-1.1.0.zip)
+* [Jakarta JSON Processing 1.1 TCK](https://download.eclipse.org/jakartaee/jsonp/1.1/jakarta-jsonp-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonp/1.1/jakarta-jsonp-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/jsonp/1.1/jakarta-jsonp-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.json:jakarta.json-api:jar:1.1.6](https://search.maven.org/artifact/jakarta.json/jakarta.json-api/1.1.6/jar)
 

--- a/mail/1.6/_index.md
+++ b/mail/1.6/_index.md
@@ -9,7 +9,7 @@ Jakarta Mail defines a platform-independent and protocol-independent framework t
 * [Jakarta Mail 1.6 Specification Document](./mail-spec-1.6.pdf) (PDF)
 * [Jakarta Mail 1.6 Specification Document](./mail-spec-1.6.html) (HTML)
 * [Jakarta Mail 1.6 Javadoc](./apidocs)
-* [Jakarta Mail 1.6 TCK](https://download.eclipse.org/jakartaee/mail/1.6/eclipse-mail-tck-1.6.0.zip)
+* [Jakarta Mail 1.6 TCK](https://download.eclipse.org/jakartaee/mail/1.6/jakarta-mail-tck-1.6.0.zip) ([sig](https://download.eclipse.org/jakartaee/mail/1.6/jakarta-mail-tck-1.6.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/mail/1.6/jakarta-mail-tck-1.6.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.mail:jakarta.mail-api:jar:1.6.4](https://search.maven.org/artifact/jakarta.mail/jakarta.mail-api/1.6.4/jar)
 

--- a/managedbeans/1.0/_index.md
+++ b/managedbeans/1.0/_index.md
@@ -9,7 +9,7 @@ with minimal requirements, otherwise known under the acronym POJOs (Plain Old Ja
 * [Jakarta Managed Beans 1.0 Specification Document](./managedbeans-spec-1.0.pdf) (PDF)
 * [Jakarta Managed Beans 1.0 Specification Document](./managedbeans-spec-1.0.html) (HTML)
 * Jakarta Managed Beans 1.0 Javadoc - N/A (covered by [Jakarta Annotations](https://jakarta.ee/specifications/annotations/1.3/))
-* Jakarta Managed Beans 1.0 TCK - N/A  (covered by [Jakarta EE Platform TCK](https://download.eclipse.org/jakartaee/platform/8/eclipse-jakartaeetck-8.0.1.zip))
+* Jakarta Managed Beans 1.0 TCK - N/A  (covered by [Jakarta EE Platform TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub)))
 * Maven coordinates (provided by Jakarta Annotations)
   * [jakarta.annotation:jakarta.annotation-api:jar:1.3.4](https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.4/jakarta.annotation-api-1.3.4.jar)
 

--- a/messaging/2.0/_index.md
+++ b/messaging/2.0/_index.md
@@ -9,7 +9,7 @@ Jakarta Messaging describes a means for Java applications to create, send, and r
 * [Jakarta Messaging 2.0 Specification Document](./messaging-spec-2.0.pdf) (PDF)
 * [Jakarta Messaging 2.0 Specification Document](./messaging-spec-2.0.html) (HTML)
 * [Jakarta Messaging 2.0 Javadoc](./apidocs)
-* [Jakarta Messaging 2.0 TCK](https://download.eclipse.org/jakartaee/messaging/2.0/jakarta-messaging-tck-2.0.0.zip)
+* [Jakarta Messaging 2.0 TCK](https://download.eclipse.org/jakartaee/messaging/2.0/jakarta-messaging-tck-2.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/messaging/2.0/jakarta-messaging-tck-2.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/messaging/2.0/jakarta-messaging-tck-2.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.jms:jakarta.jms-api:jar:2.0.3](https://search.maven.org/artifact/jakarta.jms/jakarta.jms-api/2.0.3/jar)
 

--- a/pages/2.3/_index.md
+++ b/pages/2.3/_index.md
@@ -10,7 +10,7 @@ into a Jakarta Servlet.
 * [Jakarta Server Pages 2.3 Specification Document](./pages-spec-2.3.pdf) (PDF)
 * [Jakarta Server Pages 2.3 Specification Document](./pages-spec-2.3.html) (HTML)
 * [Jakarta Server Pages 2.3 Javadoc](./apidocs)
-* [Jakarta Server Pages 2.3 TCK](https://download.eclipse.org/jakartaee/pages/2.3/eclipse-pages-tck-2.3.0.zip)
+* [Jakarta Server Pages 2.3 TCK](https://download.eclipse.org/jakartaee/pages/2.3/jakarta-pages-tck-2.3.0.zip) ([sig](https://download.eclipse.org/jakartaee/pages/2.3/jakarta-pages-tck-2.3.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/pages/2.3/jakarta-pages-tck-2.3.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.servlet.jsp:jakarta.servlet.jsp-api:jar:2.3.6](https://search.maven.org/artifact/jakarta.servlet.jsp/jakarta.servlet.jsp-api/2.3.6/jar)
 

--- a/persistence/2.2/_index.md
+++ b/persistence/2.2/_index.md
@@ -9,7 +9,7 @@ and object/relational mapping in Java(R) environments.
 * [Jakarta Persistence 2.2 Specification Document](./persistence_2.2.pdf) (PDF)
 * [Jakarta Persistence 2.2 Specification Document](./persistence_2.2.html) (HTML)
 * [Jakarta Persistence 2.2 Javadoc](./apidocs)
-* [Jakarta Persistence 2.2 TCK](https://download.eclipse.org/jakartaee/persistence/2.2/eclipse-persistence-tck-2.2.0.zip)
+* [Jakarta Persistence 2.2 TCK](https://download.eclipse.org/jakartaee/persistence/2.2/jakarta-persistence-tck-2.2.0.zip) ([sig](https://download.eclipse.org/jakartaee/persistence/2.2/jakarta-persistence-tck-2.2.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/persistence/2.2/jakarta-persistence-tck-2.2.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.persistence:jakarta.persistence-api:jar:2.2.3](https://search.maven.org/artifact/jakarta.persistence/jakarta.persistence-api/2.2.3/jar)
 

--- a/platform/8/_index.md
+++ b/platform/8/_index.md
@@ -8,7 +8,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 8 Specification Document](./platform-spec-8.pdf) (PDF)
 * [Jakarta EE Platform 8 Specification Document](./platform-spec-8.html) (HTML)
 * [Jakarta EE Platform 8 Javadoc](./apidocs)
-* [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8/eclipse-jakartaeetck-8.0.0.zip)
+* [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/8.0.0/jar)
 

--- a/restful-ws/2.1/_index.md
+++ b/restful-ws/2.1/_index.md
@@ -9,7 +9,7 @@ following the Representational State Transfer (REST) architectural pattern.
 * [Jakarta RESTful Web Services 2.1 Specification Document](restful-ws-spec-2.1.pdf) (PDF)
 * [Jakarta RESTful Web Services 2.1 Specification Document](restful-ws-spec-2.1.html) (HTML)
 * [Jakarta RESTful Web Services 2.1 Javadoc](./apidocs)
-* [Jakarta RESTful Web Services 2.1 TCK](https://download.eclipse.org/jakartaee/restful-ws/2.1/eclipse-restful-ws-tck-2.1.0.zip)
+* [Jakarta RESTful Web Services 2.1 TCK](https://download.eclipse.org/jakartaee/restful-ws/2.1/jakarta-restful-ws-tck-2.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/restful-ws/2.1/jakarta-restful-ws-tck-2.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/restful-ws/2.1/jakarta-restful-ws-tck-2.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.ws.rs:jakarta.ws.rs-api:2.1.6](https://search.maven.org/artifact/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/jar)
 

--- a/security/1.0/_index.md
+++ b/security/1.0/_index.md
@@ -8,7 +8,7 @@ Jakarta Security defines a standard for creating secure Jakarta EE applications 
 * [Jakarta Security 1.0 Specification Document](./security-spec-1.0.pdf) (PDF)
 * [Jakarta Security 1.0 Specification Document](./security-spec-1.0.html) (HTML)
 * [Jakarta Security 1.0 Javadoc](./apidocs)
-* [Jakarta Security 1.0 TCK](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip)
+* [Jakarta Security 1.0 TCK](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.security.enterprise:jakarta.security.enterprise-api:jar:1.0.2](https://search.maven.org/artifact/jakarta.security.enterprise/jakarta.security.enterprise-api/1.0.2/jar)
 

--- a/servlet/4.0/_index.md
+++ b/servlet/4.0/_index.md
@@ -8,7 +8,7 @@ Jakarta Servlet defines a server-side API for handling HTTP requests and respons
 * [Jakarta Servlet 4.0 Specification Document](./servlet-spec-4.0.pdf) (PDF)
 * [Jakarta Servlet 4.0 Specification Document](./servlet-spec-4.0.html) (HTML)
 * [Jakarta Servlet 4.0 Javadoc](./apidocs)
-* [Jakarta Servlet 4.0 TCK](https://download.eclipse.org/jakartaee/servlet/4.0/jakarta-servlet-tck-4.0.0.zip)
+* [Jakarta Servlet 4.0 TCK](https://download.eclipse.org/jakartaee/servlet/4.0/jakarta-servlet-tck-4.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/servlet/4.0/jakarta-servlet-tck-4.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/servlet/4.0/jakarta-servlet-tck-4.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.servlet:jakarta.servlet-api:jar:4.0.3](https://search.maven.org/artifact/jakarta.servlet/jakarta.servlet-api/4.0.3/jar)
 

--- a/tags/1.2/_index.md
+++ b/tags/1.2/_index.md
@@ -12,7 +12,7 @@ existing custom tags with Jakarta Standard Tag Library tags.
 * [Jakarta Standard Tag Library 1.2 Specification Document](./tags-1.2-spec.html) (HTML)
 * [Jakarta Standard Tag Library 1.2 Javadoc](./apidocs)
 * [Jakarta Standard Tag Library 1.2 Tagdoc](./tagdocs)
-* [Jakarta Standard Tag Library 1.2 TCK](https://download.eclipse.org/jakartaee/tags/1.2/eclipse-tags-tck-1.2.0.zip)
+* [Jakarta Standard Tag Library 1.2 TCK](https://download.eclipse.org/jakartaee/tags/1.2/jakarta-tags-tck-1.2.0.zip) ([sig](https://download.eclipse.org/jakartaee/tags/1.2/jakarta-tags-tck-1.2.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/tags/1.2/jakarta-tags-tck-1.2.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:jar:1.2.7](https://search.maven.org/artifact/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/1.2.7/jar)
 

--- a/transactions/1.3/_index.md
+++ b/transactions/1.3/_index.md
@@ -8,7 +8,7 @@ Jakarta Transactions
 * [Jakarta Transactions 1.3 Specification Document](./transactions-spec-1.3.pdf) (PDF)
 * [Jakarta Transactions 1.3 Specification Document](./transactions-spec-1.3.html) (HTML)
 * [Jakarta Transactions 1.3 Javadoc](./apidocs)
-* [Jakarta Transactions 1.3 TCK](https://download.eclipse.org/jakartaee/transactions/1.3/eclipse-transactions-tck-1.3.0.zip)
+* [Jakarta Transactions 1.3 TCK](https://download.eclipse.org/jakartaee/transactions/1.3/jakarta-transactions-tck-1.3.0.zip) ([sig](https://download.eclipse.org/jakartaee/transactions/1.3/jakarta-transactions-tck-1.3.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/transactions/1.3/jakarta-transactions-tck-1.3.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.transaction:jakarta.transaction-api:jar:1.3.3](https://search.maven.org/artifact/jakarta.transaction/jakarta.transaction-api/1.3.3/jar)
 

--- a/webprofile/8/_index.md
+++ b/webprofile/8/_index.md
@@ -8,7 +8,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta EE Web Profile 8 Specification Document](./webprofile-spec-8.pdf) (PDF)
 * [Jakarta EE Web Profile 8 Specification Document](./webprofile-spec-8.html) (HTML)
 * [Jakarta EE Web Profile 8 Javadoc](./apidocs)
-* [Jakarta EE Web Profile 8 TCK](https://download.eclipse.org/jakartaee/platform/8/eclipse-jakartaeetck-8.0.0.zip)
+* [Jakarta EE Web Profile 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-web-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/8.0.0/jar)
 

--- a/websocket/1.1/_index.md
+++ b/websocket/1.1/_index.md
@@ -9,7 +9,7 @@ for the WebSocket protocol (RFC6455).
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.pdf) (PDF)
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.html) (HTML)
 * [Jakarta WebSocket 1.1 Javadoc](./apidocs)
-* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip)
+* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.websocket:jakarta.websocket-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-api/1.1.2/jar)
   * [jakarta.websocket:jakarta.websocket-client-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-client-api/1.1.2/jar)

--- a/xml-registries/1.0/_index.md
+++ b/xml-registries/1.0/_index.md
@@ -11,7 +11,7 @@ All access to registry content is exposed via the interfaces defined for the Reg
 * [Jakarta XML Registries 1.0 Specification Document](./xml-registries-spec-1.0.pdf) (PDF)
 * [Jakarta XML Registries 1.0 Specification Document](./xml-registries-spec-1.0.html) (HTML)
 * [Jakarta XML Registries 1.0 Javadoc](./apidocs)
-* [Jakarta XML Registries 1.0 TCK](https://download.eclipse.org/jakartaee/xml-registries/1.0/eclipse-xml-registries-tck-1.0.0.zip)
+* [Jakarta XML Registries 1.0 TCK](https://download.eclipse.org/jakartaee/xml-registries/1.0/jakarta-xml-registries-tck-1.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/xml-registries/1.0/jakarta-xml-registries-tck-1.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/xml-registries/1.0/jakarta-xml-registries-tck-1.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.xml.registry:jakarta.xml.registry-api:jar:1.0.10](https://search.maven.org/artifact/jakarta.xml.registry/jakarta.xml.registry-api/1.0.10/jar)
 

--- a/xml-rpc/1.1/_index.md
+++ b/xml-rpc/1.1/_index.md
@@ -8,7 +8,7 @@ Jakarta XML-based RPC defines consistent Java APIs for using XML based RPC stand
 * [Jakarta XML RPC 1.1 Specification Document](./xml-rpc-spec-1.1.pdf) (PDF)
 * [Jakarta XML RPC 1.1 Specification Document](./xml-rpc-spec-1.1.html) (HTML)
 * [Jakarta XML RPC 1.1 Javadoc](./apidocs)
-* [Jakarta XML RPC 1.1 TCK](http://download.eclipse.org/jakartaee/xml-rpc/1.1/eclipse-xml-rpc-tck-1.1.0.zip)
+* [Jakarta XML RPC 1.1 TCK](https://download.eclipse.org/jakartaee/xml-rpc/1.1/jakarta-xml-rpc-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/xml-rpc/1.1/jakarta-xml-rpc-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/xml-rpc/1.1/jakarta-xml-rpc-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.xml.rpc:jakarta.xml.rpc-api:jar:1.1.4](https://search.maven.org/artifact/jakarta.xml.rpc/jakarta.xml.rpc-api/1.1.4/jar)
 


### PR DESCRIPTION
 - TCK urls have been updated to favor the 'jakarta-' version of files if the 'eclipse-' prefix was used.
 - All downloads.eclipse.org URLs now use `https`
 - After each TCK link there is a new `(sig,sha,pub)` set of links for verification
