### PR TITLE
Fix links to WebSocket TCK and associated downloads

### DIFF
--- a/websocket/1.1/_index.md
+++ b/websocket/1.1/_index.md
@@ -9,7 +9,7 @@ for the WebSocket protocol (RFC6455).
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.pdf) (PDF)
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.html) (HTML)
 * [Jakarta WebSocket 1.1 Javadoc](./apidocs)
-* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip) ([sig](http://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sig),[sha](http://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.websocket:jakarta.websocket-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-api/1.1.2/jar)
   * [jakarta.websocket:jakarta.websocket-client-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-client-api/1.1.2/jar)

--- a/websocket/1.1/_index.md
+++ b/websocket/1.1/_index.md
@@ -9,7 +9,7 @@ for the WebSocket protocol (RFC6455).
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.pdf) (PDF)
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.html) (HTML)
 * [Jakarta WebSocket 1.1 Javadoc](./apidocs)
-* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip) ([sig](http://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sig),[sha](http://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.websocket:jakarta.websocket-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-api/1.1.2/jar)
   * [jakarta.websocket:jakarta.websocket-client-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-client-api/1.1.2/jar)

--- a/websocket/1.1/_index.md
+++ b/websocket/1.1/_index.md
@@ -9,7 +9,7 @@ for the WebSocket protocol (RFC6455).
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.pdf) (PDF)
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.html) (HTML)
 * [Jakarta WebSocket 1.1 Javadoc](./apidocs)
-* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/websocket-api/1.1/websocket-api-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip) ([sig](http://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sig),[sha](http://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.websocket:jakarta.websocket-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-api/1.1.2/jar)
   * [jakarta.websocket:jakarta.websocket-client-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-client-api/1.1.2/jar)


### PR DESCRIPTION
Correct TCK (.zip, .sig, and .sha256) download links.

Signed-off-by: Ed Bratt <ed.bratt@oracle.com>