### PR TITLE
Add template for Jakarta EE 9 for further discussion

### DIFF
--- a/platform/9/_index.md
+++ b/platform/9/_index.md
@@ -5,4 +5,52 @@ summary: "Release of the Jakarta EE 9 Platform"
 ---
 The Jakarta EE Platform defines a standard platform for hosting Jakarta EE applications.
 
-# The rest of this needs to be filled in like the previous release...
+* [Jakarta EE Platform 9 Release Record](https://projects.eclipse.org/projects/ee4j.jakartaee-platform/releases/9)
+  * [Jakarta EE Platform 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan)
+* [Jakarta EE Platform 9 Specification Document]() (PDF)
+* [Jakarta EE Platform 9 Specification Document]() (HTML)
+* [Jakarta EE Platform 9 Javadoc](./apidocs)
+* [Jakarta EE Platform 9 TCK]()([sig](),[sha](),[pub]())
+* Maven coordinates
+  * [jakarta.platform:jakarta.jakartaee-api:jar:9.0.0]()
+
+# Compatible Implementations
+* [Eclipse Glassfish x.y]()
+
+# Ballots
+
+## Plan Review
+
+The Specification Committee Ballot concluded successfully on 2020-mm-dd with the following results.
+
+|                       |  Yes    | No      | Abstain  |
+|-----------------------|---------|---------|----------|
+|Fujitsu                |         |         |          |
+|IBM                    |         |         |          |
+|Oracle                 |         |         |          |
+|Payara                 |         |         |          |
+|Red Hat                |         |         |          |
+|Tomitribe              |         |         |          |
+|EE4J PMC               |         |         |          |
+|Participant Members    |         |         |          |
+|Committer Members      |         |         |          |
+
+The ballot was run in the [jakarta.ee-spec mailing list]()
+
+## Release Review
+
+The Specification Committee Ballot concluded successfully on 2019-09-09 with the following results.
+
+|                       |  Yes    | No      | Abstain  |
+|-----------------------|---------|---------|----------|
+|Fujitsu                |         |         |          |
+|IBM                    |         |         |          |
+|Oracle                 |         |         |          |
+|Payara                 |         |         |          |
+|Red Hat                |         |         |          |
+|Tomitribe              |         |         |          |
+|EE4J PMC               |         |         |          |
+|Participant Members    |         |         |          |
+|Committer Members      |         |         |          |
+
+The ballot was run in the [jakarta.ee-spec mailing list]()


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Starting with a simple update for the Jakarta EE 9 _index.md record.  Let's play with this content and format before applying it across the board.

Besides the information for the Release Plan, I also moved the Compatible Implementation section up to push the boring Ballots to the bottom.  The Ballots take up too much room.  And, if we add Progress Reviews to this section, or if we have to do a re-do, this Ballot section will just continue to grow and make these pages unusable.  I'm hoping that putting it at the bottom of the page is sufficient.
