### PR TITLE
Update platform TCK links to latest 8.0.2 version. Standalone TCKs authentication-tck-1.1.1.zip, authorization-tck-1.5.1.zip, connectors-tck-1.7.1.zip, security-tck-1.0.1.zip, websocket-tck-1.1.1.zip.  (jakartaee-platform/issue#139)

### DIFF
--- a/authentication/1.1/_index.md
+++ b/authentication/1.1/_index.md
@@ -13,7 +13,7 @@ Jakarta Authentication consists of several profiles, with each profile telling h
 * [Jakarta Authentication 1.1 Specification Document](./authentication-spec-1.1.pdf) (PDF)
 * [Jakarta Authentication 1.1 Specification Document](./authentication-spec-1.1.html) (HTML)
 * [Jakarta Authentication 1.1 Javadoc](./apidocs)
-* [Jakarta Authentication 1.1 TCK](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Authentication 1.1 TCK](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.1.zip) ([sig](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/authentication/1.1/jakarta-authentication-tck-1.1.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.security.auth.message:jakarta.security.auth.message-api:jar:1.1.3](https://search.maven.org/artifact/jakarta.security.auth.message/jakarta.security.auth.message-api/1.1.3/jar)
 

--- a/authorization/1.5/_index.md
+++ b/authorization/1.5/_index.md
@@ -11,7 +11,7 @@ these permissions.
 * [Jakarta Authorization 1.5 Specification Document](./authorization-spec-1.5.pdf) (PDF)
 * [Jakarta Authorization 1.5 Specification Document](./authorization-spec-1.5.html) (HTML)
 * [Jakarta Authorization 1.5 Javadoc](./apidocs)
-* [Jakarta Authorization 1.5 TCK](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip) ([sig](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Authorization 1.5 TCK](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.1.zip) ([sig](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/authorization/1.5/jakarta-authorization-tck-1.5.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.authorization:jakarta.authorization-api:jar:1.5.0](https://search.maven.org/artifact/jakarta.authorization/jakarta.authorization-api/1.5.0/jar)
 

--- a/connectors/1.7/_index.md
+++ b/connectors/1.7/_index.md
@@ -8,7 +8,7 @@ The Jakarta Connectors specification defines a standard architecture for Jakarta
 * [Jakarta Connectors 1.7 Specification Document](./connectors-spec-1.7.pdf) (PDF)
 * [Jakarta Connectors 1.7 Specification Document](./connectors-spec-1.7.html) (HTML)
 * [Jakarta Connectors 1.7 Javadoc](./apidocs)
-* [Jakarta Connectors 1.7 TCK](http://download.eclipse.org/jakartaee/connectors/1.7/jakarta-connectors-tck-1.7.0.zip) ([sig](http://download.eclipse.org/jakartaee/connectors/1.7/jakarta-connectors-tck-1.7.0.zip.sig),[sha](http://download.eclipse.org/jakartaee/connectors/1.7/jakarta-connectors-tck-1.7.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Connectors 1.7 TCK](http://download.eclipse.org/jakartaee/connectors/1.7/jakarta-connectors-tck-1.7.1.zip) ([sig](http://download.eclipse.org/jakartaee/connectors/1.7/jakarta-connectors-tck-1.7.1.zip.sig),[sha](http://download.eclipse.org/jakartaee/connectors/1.7/jakarta-connectors-tck-1.7.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.resource:jakarta.resource-api:jar:1.7.4](https://search.maven.org/artifact/jakarta.resource/jakarta.resource-api/1.7.4/jar)
 

--- a/platform/8/_index.md
+++ b/platform/8/_index.md
@@ -8,7 +8,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 8 Specification Document](./platform-spec-8.pdf) (PDF)
 * [Jakarta EE Platform 8 Specification Document](./platform-spec-8.html) (HTML)
 * [Jakarta EE Platform 8 Javadoc](./apidocs)
-* [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/8.0.0/jar)
 

--- a/security/1.0/_index.md
+++ b/security/1.0/_index.md
@@ -8,7 +8,7 @@ Jakarta Security defines a standard for creating secure Jakarta EE applications 
 * [Jakarta Security 1.0 Specification Document](./security-spec-1.0.pdf) (PDF)
 * [Jakarta Security 1.0 Specification Document](./security-spec-1.0.html) (HTML)
 * [Jakarta Security 1.0 Javadoc](./apidocs)
-* [Jakarta Security 1.0 TCK](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Security 1.0 TCK](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/security/1.0/jakarta-security-tck-1.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.security.enterprise:jakarta.security.enterprise-api:jar:1.0.2](https://search.maven.org/artifact/jakarta.security.enterprise/jakarta.security.enterprise-api/1.0.2/jar)
 

--- a/webprofile/8/_index.md
+++ b/webprofile/8/_index.md
@@ -8,7 +8,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta EE Web Profile 8 Specification Document](./webprofile-spec-8.pdf) (PDF)
 * [Jakarta EE Web Profile 8 Specification Document](./webprofile-spec-8.html) (HTML)
 * [Jakarta EE Web Profile 8 Javadoc](./apidocs)
-* [Jakarta EE Web Profile 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta EE Web Profile 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-web-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/8.0.0/jar)
 

--- a/websocket/1.1/_index.md
+++ b/websocket/1.1/_index.md
@@ -9,7 +9,7 @@ for the WebSocket protocol (RFC6455).
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.pdf) (PDF)
 * [Jakarta WebSocket 1.1 Specification Document](./websocket-spec-1.1.html) (HTML)
 * [Jakarta WebSocket 1.1 Javadoc](./apidocs)
-* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta WebSocket 1.1 TCK](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.1.zip) ([sig](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/websocket/1.1/jakarta-websocket-tck-1.1.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.websocket:jakarta.websocket-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-api/1.1.2/jar)
   * [jakarta.websocket:jakarta.websocket-client-api:1.1.2:jar](https://search.maven.org/artifact/jakarta.websocket/jakarta.websocket-client-api/1.1.2/jar)


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

TCK testing with [certification](https://ci.eclipse.org/jakartaee-tck/view/EPL-EFTL-CERTIFICATION-JOBS/) test jobs is pending.  Via the various [build/run 802](https://ci.eclipse.org/jakartaee-tck/) TCK jobs, we did pass all of the updated standalone TCKs, Full Platform + Web Profile testing already.  I'll update this PR again once we we have passed the [certification](https://ci.eclipse.org/jakartaee-tck/view/EPL-EFTL-CERTIFICATION-JOBS/) test jobs.

- [ ] For a Release Review, a summary that a Compatible Implementation
      is complete, passes the TCK, and that the TCK includes sufficient
      coverage of the specification. The TCK users guide MUST include
      the instructions to run the compatible implementations used to
      validate the release.  Instructions MAY be by reference.
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/promoted/eclipse-jakartaeetck-8.0.2.zip
http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/promoted/eclipse-authentication-tck-1.1.1.zip
http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/promoted/eclipse-authorization-tck-1.5.1.zip
http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/promoted/eclipse-connectors-tck-1.7.1.zip
http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/promoted/eclipse-security-tck-1.0.1.zip
http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8-eftl/promoted/eclipse-websocket-tck-1.1.1.zip

