### PR TITLE
update jaxrs, ejb, and jaf templates

### DIFF
--- a/activation/2.0/_index.md
+++ b/activation/2.0/_index.md
@@ -25,10 +25,29 @@ summary: "Release for Jakarta EE 9"
 
 [//]: # (For Jakarta EE 9, the Platform Plan Review covered 95% of the Specification Projects.  For those Projects, just use the following statement in this Plan Review section:)
 
-This Specification Project's Plan Review was covered by the [Jakarta EE 9 Plan Review](https://jakarta.ee/specifications/platform/9/).  
-Please reference that ballot for the official results.
+[//]: # (This Specification Project's Plan Review was covered by the [Jakarta EE 9 Plan Review].)
+[//]: # (Please reference that ballot for the official results.)
 
 [//]: # (If your Project was required to do a standalone Plan Review...  You'll need to perform an official Plan Review ballot and record the results here.)
+
+[Jakarta Activation 2.0 Release Record and Plan]()
+
+The Specification Committee Ballot concluded successfully on 2020-mm-dd with the following results.
+
+| Representative                                 | Representative for: | Vote |
+|------------------------------------------------|---------------------|------|
+| Kenji Kazumura, Michael DeNicola               | Fujitsu             |      |
+| Dan Bandera, Kevin Sutter                      | IBM                 |      |
+| Bill Shannon, Ed Bratt                         | Oracle              |      |
+| Mark Wareham, Steve Millidge                   | Payara              |      |
+| Scott Stark, Mark Little                       | Red Hat             |      |
+| David Blevins, Cesar Hernandez                 | Tomitribe           |      |
+| Ivar Grimstad                                  | EE4J PMC            |      |
+| Alex Theedom                                   | Participant Members |      |
+| Werner Keil                                    | Committer Members   |      |
+|                                                | Total               |      |
+
+The ballot was run in the [jakarta.ee-spec mailing list]()
 
 ## Release Review
 

--- a/enterprise-beans/4.0/_index.md
+++ b/enterprise-beans/4.0/_index.md
@@ -26,10 +26,29 @@ Jakarta Enterprise Beans defines an architecture for the development and deploym
 
 [//]: # (For Jakarta EE 9, the Platform Plan Review covered 95% of the Specification Projects.  For those Projects, just use the following statement in this Plan Review section:)
 
-This Specification Project's Plan Review was covered by the [Jakarta EE 9 Plan Review](https://jakarta.ee/specifications/platform/9/).  
-Please reference that ballot for the official results.
+[//]: # (This Specification Project's Plan Review was covered by the [Jakarta EE 9 Plan Review].)
+[//]: # (Please reference that ballot for the official results.)
 
 [//]: # (If your Project was required to do a standalone Plan Review...  You'll need to perform an official Plan Review ballot and record the results here.)
+
+[Jakarta Enterprise Bean 4.0 Release Record and Plan]()
+
+The Specification Committee Ballot concluded successfully on 2020-mm-dd with the following results.
+
+| Representative                                 | Representative for: | Vote |
+|------------------------------------------------|---------------------|------|
+| Kenji Kazumura, Michael DeNicola               | Fujitsu             |      |
+| Dan Bandera, Kevin Sutter                      | IBM                 |      |
+| Bill Shannon, Ed Bratt                         | Oracle              |      |
+| Mark Wareham, Steve Millidge                   | Payara              |      |
+| Scott Stark, Mark Little                       | Red Hat             |      |
+| David Blevins, Cesar Hernandez                 | Tomitribe           |      |
+| Ivar Grimstad                                  | EE4J PMC            |      |
+| Alex Theedom                                   | Participant Members |      |
+| Werner Keil                                    | Committer Members   |      |
+|                                                | Total               |      |
+
+The ballot was run in the [jakarta.ee-spec mailing list]()
 
 ## Release Review
 

--- a/restful-ws/3.0/_index.md
+++ b/restful-ws/3.0/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "Jakarta RESTful Web Services 3.0 (under development)"
-date: 2020-mm-dd
+date: 2020-01-15
 summary: "Release for Jakarta EE 9"
 ---
 Jakarta RESTful Web Services provides a foundational API to develop web services
 following the Representational State Transfer (REST) architectural pattern.
 
-* [Jakarta RESTful Web Services 3.0 Release Record]()
+* [Jakarta RESTful Web Services 3.0 Release Record](https://projects.eclipse.org/projects/ee4j.jaxrs/releases/3.0)
   * [Jakarta EE Platform 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan)
 * [Jakarta RESTful Web Services 3.0 Specification Document]() (PDF)
 * [Jakarta RESTful Web Services 3.0 Specification Document]() (HTML)


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

JAX-RS has decided to go with a simple release for Jakarta EE 9, thus they are now covered by the overall Jakarta EE 9 Release Plan.

I have also updated the templates for EJB and JAF to better represent the need for a separate plan and review.