### PR TITLE
Enterprise Beans 4.0 Plan Review

### DIFF
--- a/enterprise-beans/4.0/_index.md
+++ b/enterprise-beans/4.0/_index.md
@@ -6,7 +6,7 @@ summary: "Release for Jakarta EE 9"
 
 Jakarta Enterprise Beans defines an architecture for the development and deployment of component-based business applications.
 
-* [Jakarta Enterprise Beans 4.0 Release Record]()
+* [Jakarta Enterprise Beans 4.0 Release Record](https://projects.eclipse.org/projects/ee4j.ejb/releases/4.0/plan)
   * [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/master/4.0-PLAN.adoc)
 * [Jakarta Enterprise Beans 4.0 Specification Document]() (PDF)
 * [Jakarta Enterprise Beans 4.0 Specification Document]() (HTML)

--- a/enterprise-beans/4.0/_index.md
+++ b/enterprise-beans/4.0/_index.md
@@ -7,7 +7,7 @@ summary: "Release for Jakarta EE 9"
 Jakarta Enterprise Beans defines an architecture for the development and deployment of component-based business applications.
 
 * [Jakarta Enterprise Beans 4.0 Release Record]()
-  * [Jakarta EE Platform 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan)
+  * [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/release-plan/4.0-PLAN.adoc)
 * [Jakarta Enterprise Beans 4.0 Specification Document]() (PDF)
 * [Jakarta Enterprise Beans 4.0 Specification Document]() (HTML)
 * [Jakarta Enterprise Beans 4.0 Javadoc](./apidocs)
@@ -15,13 +15,13 @@ Jakarta Enterprise Beans defines an architecture for the development and deploym
 * Maven coordinates
   * [jakarta.ejb:jakarta.ejb-api:jar:4.0.0]()
 
-The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the [Jakarta EE 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan), which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve removal of `java.security.Identity`, which is being removed from future versions of Java.
+The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the link:https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan[Jakarta EE 9 Release Plan], which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve three changes:
 
-Affected method signatures:
+ - Removal of methods relying on `java.security.Identity`
+ - Removal of Support for Distributed Interoperability
+ - Mark optional EJB 2.x API Group
 
- - class `javax.ejb.EJBContext` method `Identity getCallerIdentity();`
-
-Outside of this breaking change, no other changes are planned.
+See the [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/release-plan/4.0-PLAN.adoc) for full details.
 
 # Compatible Implementations
 

--- a/enterprise-beans/4.0/_index.md
+++ b/enterprise-beans/4.0/_index.md
@@ -15,10 +15,17 @@ Jakarta Enterprise Beans defines an architecture for the development and deploym
 * Maven coordinates
   * [jakarta.ejb:jakarta.ejb-api:jar:4.0.0]()
 
+The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the [Jakarta EE 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan), which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve removal of `java.security.Identity`, which is being removed from future versions of Java.
+
+Affected method signatures:
+
+ - class `javax.ejb.EJBContext` method `Identity getCallerIdentity();`
+
+Outside of this breaking change, no other changes are planned.
 
 # Compatible Implementations
 
-* [Jakarta Enterprise Beans]()
+* Pending
 
 # Ballots
 

--- a/enterprise-beans/4.0/_index.md
+++ b/enterprise-beans/4.0/_index.md
@@ -7,7 +7,7 @@ summary: "Release for Jakarta EE 9"
 Jakarta Enterprise Beans defines an architecture for the development and deployment of component-based business applications.
 
 * [Jakarta Enterprise Beans 4.0 Release Record]()
-  * [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/release-plan/4.0-PLAN.adoc)
+  * [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/master/4.0-PLAN.adoc)
 * [Jakarta Enterprise Beans 4.0 Specification Document]() (PDF)
 * [Jakarta Enterprise Beans 4.0 Specification Document]() (HTML)
 * [Jakarta Enterprise Beans 4.0 Javadoc](./apidocs)
@@ -15,13 +15,15 @@ Jakarta Enterprise Beans defines an architecture for the development and deploym
 * Maven coordinates
   * [jakarta.ejb:jakarta.ejb-api:jar:4.0.0]()
 
-The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the link:https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan[Jakarta EE 9 Release Plan], which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve three changes:
+The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the [Jakarta EE 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan), which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve three changes:
 
  - Removal of methods relying on `java.security.Identity`
+ - Removal of methods relying on JAX-RPC
+ - Removal of deprecated `EJBContext.getEnvironment()` method
  - Removal of Support for Distributed Interoperability
  - Mark optional EJB 2.x API Group
 
-See the [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/release-plan/4.0-PLAN.adoc) for full details.
+See the [Jakarta Enterprise Beans 4.0 Release Plan](https://github.com/eclipse-ee4j/ejb-api/blob/master/4.0-PLAN.adoc) for full details.
 
 # Compatible Implementations
 

--- a/enterprise-beans/4.0/_index.md
+++ b/enterprise-beans/4.0/_index.md
@@ -15,7 +15,7 @@ Jakarta Enterprise Beans defines an architecture for the development and deploym
 * Maven coordinates
   * [jakarta.ejb:jakarta.ejb-api:jar:4.0.0]()
 
-The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the [Jakarta EE 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan), which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve three changes:
+The Jakarta Enterprise Beans 4.0 intended scope includes all plans detailed in the [Jakarta EE 9 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan), which in essence involves a backwards incompatible namespace change from `javax.ejb` to `jakarta.ejb`.  In addition the Jakarta Enterprise Beans 4.0 Release Plan will involve:
 
  - Removal of methods relying on `java.security.Identity`
  - Removal of methods relying on JAX-RPC


### PR DESCRIPTION
(all text revised as of Tue Feb  4)

The current state of this PR is still solidly 'draft' as we have a few things to discuss.

 First, see this page for a draft of the proposed text for the detailed plan.  This is in PR form:

  - https://github.com/eclipse-ee4j/ejb-api/blob/053b5ceb50b5b3c63dd99f0adf568038045f0a83/4.0-PLAN.adoc#jakarta-enterprise-beans-40
  - https://github.com/eclipse-ee4j/ejb-api/pull/64

Open discussion item on if this is an acceptable place for a plan to live.  There is an open bug requesting a Github Pages setup:

 - https://bugs.eclipse.org/bugs/show_bug.cgi?id=559668

Second, I still feel we need executive summaries on our specification pages.  Understood we do not want detailed plans there, however there needs to be a one or two paragraph max executive-level overview so people do not need to read these 620 and 1600 word plans we're writing just to get an idea of what to expect.