### PR TITLE
Updated PR template to clarify that the second PR for the javadoc is optional

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,26 +1,21 @@
 ## Specification PR template
-When creating a specification project release review, create two PRs with the content divided as follows.
+When creating a specification project release review, create PRs with the content defined as follows.
 
-Include the following in PR#1:
+Include the following in the PR:
 - [ ] A directory in the form wombat/x.y where x.y is the release major.minor version, and the directory contains the following.
 - [ ] Specification PDF in the form of wombat-spec-x.y.pdf
 - [ ] Specification HTML in the form of wombat-spec-x.y.html
 - [ ] A specification page named _index.md following the template at:
       https://github.com/jakartaee/specification-committee/blob/master/spec_page_template.md
-- [ ] For a Progress Review, that sufficient progress has been made on
-      a Compatible Implementation and TCK, to ensure that the spec is
-      implementable and testable.
-- [ ] For a Release Review, a summary that a Compatible Implementation
-      is complete, passes the TCK, and that the TCK includes sufficient
-      coverage of the specification. The TCK users guide MUST include
-      the instructions to run the compatible implementations used to
-      validate the release.  Instructions MAY be by reference.
+- [ ] For a Progress Review, that sufficient progress has been made on a Compatible Implementation and TCK, to ensure that the spec is implementable and testable.
+- [ ] For a Release Review, a summary that a Compatible Implementation is complete, passes the TCK, and that the TCK includes sufficient coverage of the specification.
+The TCK users guide MUST include the instructions to run the compatible implementations used to validate the release.
+Instructions MAY be by reference.
 - [ ] The URL of the OSSRH staging repository for the api, javadoc:
       <add URL here>
 - [ ] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
       <add URL here>
 - [ ] The URL of the compatibility certification request issue:
       <add URL here>
-
-Include the following in PR#2:
-- [ ] Specification JavaDoc in the wombat/x.y/apidocs directory.
+- [ ] Specification JavaDoc in the wombat/x.y/apidocs directory. 
+If desired, an optional second PR can be created to contain just the JavaDoc in the `apidocs` directory.


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Main point was to indicate that separating the javadoc into its own PR is an optional exercise.  As I was updating that, I found a couple of minor formatting items that I also cleaned up.

