### PR TITLE
Corrected download links to TCK for Jakarta Activation 1.2

### DIFF
--- a/activation/1.2/_index.md
+++ b/activation/1.2/_index.md
@@ -11,7 +11,7 @@ appropriate bean to perform the operation(s).
 * [Jakarta Activation 1.2 Specification Document](./activation-spec-1.2.pdf) (PDF)
 * [Jakarta Activation 1.2 Specification Document](./activation-spec-1.2.html) (HTML)
 * [Jakarta Activation 1.2 Javadoc](./apidocs)
-* [Jakarta Activation 1.2 TCK](http://downloads.eclipse.org/jakarta/activation/1.2/jakarta-activation-tck-1.2.0.zip) ([sig](http://downloads.eclipse.org/jakarta/activation/1.2/jakarta-activation-tck-1.2.0.zip.sig),[sha](http://downloads.eclipse.org/jakarta/activation/1.2/jakarta-activation-tck-1.2.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Activation 1.2 TCK](https://download.eclipse.org/jakartaee/activation/1.2/jakarta-activation-tck-1.2.0.zip) ([sig](https://download.eclipse.org/jakartaee/activation/1.2/jakarta-activation-tck-1.2.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/activation/1.2/jakarta-activation-tck-1.2.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.activation:jakarta.activation-api:jar:1.2.2](https://search.maven.org/artifact/jakarta.activation/jakarta.activation-api/1.2.2/jar)
 


### PR DESCRIPTION
Fix to download link to Jakarta Activation 1.2 TCK and SHA file links. (FWIW SHA appears to match that in the CCR from last year.)

Signed-off-by: Ed Bratt <ed.bratt@oracle.com>