### PR TITLE
Insert Bean Validation ballot and correct sha link

### DIFF
--- a/bean-validation/3.0/_index.md
+++ b/bean-validation/3.0/_index.md
@@ -12,7 +12,7 @@ Jakarta Bean Validation defines a metadata model and API for JavaBean and method
 * [Jakarta Bean Validation 3.0 Javadoc](./apidocs)
 * [Jakarta Bean Validation 3.0 TCK](https://download.eclipse.org/jakartaee/bean-validation/3.0/beanvalidation-tck-dist-3.0.0.zip)
 ([sig](https://download.eclipse.org/jakartaee/bean-validation/3.0/beanvalidation-tck-dist-3.0.0.zip.sig),
-[sha](c975fd229df0c40947a9f0a69b779ec92bebb3d21e05fdc65fccc1d11ef5525b),
+[sha](https://download.eclipse.org/jakartaee/bean-validation/3.0/beanvalidation-tck-dist-3.0.0.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 
 * Maven coordinates
@@ -35,19 +35,20 @@ Please reference that ballot for the official results.
 
 ## Release Review
 
-The Specification Committee Ballot concluded successfully on 2020-mm-dd with the following results.
+The Specification Committee Ballot concluded successfully on 2020-08-26 with the following results.
 
 | Representative                                 | Representative for: | Vote |
 |------------------------------------------------|---------------------|------|
-| Kenji Kazumura, Michael DeNicola               | Fujitsu             |      |
-| Dan Bandera, Kevin Sutter                      | IBM                 |      |
-| Bill Shannon, Ed Bratt                         | Oracle              |      |
-| Mark Wareham, Steve Millidge                   | Payara              |      |
-| Scott Stark, Mark Little                       | Red Hat             |      |
-| David Blevins, Cesar Hernandez                 | Tomitribe           |      |
-| Ivar Grimstad                                  | EE4J PMC            |      |
-| Alex Theedom                                   | Participant Members |      |
-| Werner Keil                                    | Committer Members   |      |
-|                                                | Total               |      |
+| Kenji Kazumura                                 | Fujitsu             |   1  |
+| Dan Bandera, Kevin Sutter                      | IBM                 |   1  |
+| Ed Bratt, Dmitry Kornilov                      | Oracle              |   1  |
+| Andrew Pielage, Matt Gill                      | Payara              |   1  |
+| Scott Stark, Mark Little                       | Red Hat             |   1  |
+| David Blevins, Cesar Hernandez                 | Tomitribe           |   1  |
+| Ivar Grimstad                                  | EE4J PMC            |   1  |
+| Marcelo Ancelmo, Martijn Verburg               | Participant Members |   1  |
+| Werner Keil                                    | Committer Members   |   1  |
+| Scott (Congquan) Wang                          | Enterprise Members  |   1  |
+|                                                | Total               |  10  |
 
-The ballot was run in the [jakarta.ee-spec mailing list]()
+The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg00723.html)

--- a/bean-validation/3.0/_index.md
+++ b/bean-validation/3.0/_index.md
@@ -39,16 +39,16 @@ The Specification Committee Ballot concluded successfully on 2020-08-26 with the
 
 | Representative                                 | Representative for: | Vote |
 |------------------------------------------------|---------------------|------|
-| Kenji Kazumura                                 | Fujitsu             |   1  |
-| Dan Bandera, Kevin Sutter                      | IBM                 |   1  |
-| Ed Bratt, Dmitry Kornilov                      | Oracle              |   1  |
-| Andrew Pielage, Matt Gill                      | Payara              |   1  |
-| Scott Stark, Mark Little                       | Red Hat             |   1  |
-| David Blevins, Jean-Louis Monteiro             | Tomitribe           |   1  |
-| Ivar Grimstad                                  | EE4J PMC            |   1  |
-| Marcelo Ancelmo, Martijn Verburg               | Participant Members |   1  |
-| Werner Keil                                    | Committer Members   |   1  |
-| Scott (Congquan) Wang                          | Enterprise Members  |   1  |
+| Kenji Kazumura                                 | Fujitsu             |  +1  |
+| Dan Bandera, Kevin Sutter                      | IBM                 |  +1  |
+| Ed Bratt, Dmitry Kornilov                      | Oracle              |  +1  |
+| Andrew Pielage, Matt Gill                      | Payara              |  +1  |
+| Scott Stark, Mark Little                       | Red Hat             |  +1  |
+| David Blevins, Jean-Louis Monteiro             | Tomitribe           |  +1  |
+| Ivar Grimstad                                  | EE4J PMC            |  +1  |
+| Marcelo Ancelmo, Martijn Verburg               | Participant Members |  +1  |
+| Werner Keil                                    | Committer Members   |  +1  |
+| Scott (Congquan) Wang                          | Enterprise Members  |  +1  |
 |                                                | Total               |  10  |
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg00723.html)

--- a/bean-validation/3.0/_index.md
+++ b/bean-validation/3.0/_index.md
@@ -44,7 +44,7 @@ The Specification Committee Ballot concluded successfully on 2020-08-26 with the
 | Ed Bratt, Dmitry Kornilov                      | Oracle              |   1  |
 | Andrew Pielage, Matt Gill                      | Payara              |   1  |
 | Scott Stark, Mark Little                       | Red Hat             |   1  |
-| David Blevins, Cesar Hernandez                 | Tomitribe           |   1  |
+| David Blevins, Jean-Louis Monteiro             | Tomitribe           |   1  |
 | Ivar Grimstad                                  | EE4J PMC            |   1  |
 | Marcelo Ancelmo, Martijn Verburg               | Participant Members |   1  |
 | Werner Keil                                    | Committer Members   |   1  |


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Updated _index.md with the ballot results.  And, corrected the sha link for the TCK.