### PR TITLE
Updated ballot results and confirmed TCK download specifics

### DIFF
--- a/dependency-injection/2.0/_index.md
+++ b/dependency-injection/2.0/_index.md
@@ -54,4 +54,4 @@ The Specification Committee Ballot concluded successfully on 2020-08-27 with the
 | Scott (Congquan) Wang                          | Enterprise Members  |  +1  |
 |                                                | Total               |  10  |
 
-The ballot was run in the [jakarta.ee-spec mailing list]()
+The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg00786.html)

--- a/dependency-injection/2.0/_index.md
+++ b/dependency-injection/2.0/_index.md
@@ -13,7 +13,7 @@ Jakarta Dependency Injection specifies a means for obtaining objects in such a w
 * [Jakarta Dependency Injection 2.0 Javadoc](./apidocs)
 * [Jakarta Dependency Injection 2.0 TCK](https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.1-bin.zip)
 ([sig](https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.1-bin.zip.sig),
-[sha](7853d02d372838f8300f5a18cfcc23011c9eb9016cf3980bba9442e4b1f8bfc6),
+[sha](https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.1-bin.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
   * TCK Summary Results [Weld 4.0.0.Alpha2](https://github.com/jakartaredhat/weld-inject-tck/wiki/Jakarta-Dependency-Injection-2.0-TCK-Results)
 

--- a/dependency-injection/2.0/_index.md
+++ b/dependency-injection/2.0/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta Dependency Injection 2.0"
-date: 2020-08-05
+date: 2020-08-26
 summary: "Release for Jakarta EE 9"
 ---
 
@@ -38,19 +38,20 @@ Please reference that ballot for the official results.
 
 ## Release Review
 
-The Specification Committee Ballot concluded successfully on 2020-mm-dd with the following results.
+The Specification Committee Ballot concluded successfully on 2020-08-27 with the following results.
 
 | Representative                                 | Representative for: | Vote |
 |------------------------------------------------|---------------------|------|
-| Kenji Kazumura, Michael DeNicola               | Fujitsu             |      |
-| Dan Bandera, Kevin Sutter                      | IBM                 |      |
-| Bill Shannon, Ed Bratt                         | Oracle              |      |
-| Mark Wareham, Steve Millidge                   | Payara              |      |
-| Scott Stark, Mark Little                       | Red Hat             |      |
-| David Blevins, Cesar Hernandez                 | Tomitribe           |      |
-| Ivar Grimstad                                  | EE4J PMC            |      |
-| Alex Theedom                                   | Participant Members |      |
-| Werner Keil                                    | Committer Members   |      |
-|                                                | Total               |      |
+| Kenji Kazumura                                 | Fujitsu             |  +1  |
+| Dan Bandera, Kevin Sutter                      | IBM                 |  +1  |
+| Ed Bratt, Dmitry Kornilov                      | Oracle              |  +1  |
+| Andrew Pielage, Matt Gill                      | Payara              |  +1  |
+| Scott Stark, Mark Little                       | Red Hat             |  +1  |
+| David Blevins, Jean-Louis Monteiro             | Tomitribe           |  +1  |
+| Ivar Grimstad                                  | EE4J PMC            |  +1  |
+| Marcelo Ancelmo, Martijn Verburg               | Participant Members |  +1  |
+| Werner Keil                                    | Committer Members   |  +1  |
+| Scott (Congquan) Wang                          | Enterprise Members  |  +1  |
+|                                                | Total               |  10  |
 
 The ballot was run in the [jakarta.ee-spec mailing list]()


### PR DESCRIPTION
 - [x] The specification committee mentor adds this final checklist to the main PR.
 - [x] The specification committee member adds the `approved` label to the PRs, and sends out the Ballot Summary per this [template](#ballot-summary-email-template) to the [public Jakarta EE Specification Committee email list](jakarta.ee-spec@eclipse.org)
  - [x] The specification committee mentor merges the specification (and apidocs) PRs, ensuring the "date:" field in the _index.md file has an appropriate value to allow publishing.
 - [x] The specification committee mentor calculates the staged EFTL TCK signature and promotes it to the committee download area
  using the https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/ job.
 - [x] The specification project member who created the api staging release promotes the specification api jars to maven central. An example release job script can be found here https://wiki.eclipse.org/MavenReleaseScript.
 - [x] The specification committee mentor updates the specification page with the ballot results.
This list goes on the committed spec index page.
 - [x] The specification project team should go through the merged spec website page to verify all the links are valid.
 - [x] The specification project team should approve the compatibility request.
 - [x] The compatible implementation project/vendor MUST send an email to tck@eclipse.org for approval of the compatible implementation for trademark usage.
 - [x] The specification project team should merge any final release branch as appropriate for the branch management for the project.

Signed-off-by: Ed Bratt <ed.bratt@oracle.com>