### PR TITLE
Fix broken link for JAF impl

### DIFF
--- a/activation/1.2/_index.md
+++ b/activation/1.2/_index.md
@@ -36,4 +36,4 @@ The Release Review Specification Committee Ballot concluded successfully on 2020
 
 # Compatible Implementations
 
-* [Eclipse implementation of Jakarta Activation 1.2.2](https://github.com/eclipse-ee4j/activation)
+* [Eclipse implementation of Jakarta Activation 1.2.2](https://github.com/eclipse-ee4j/jaf)


### PR DESCRIPTION
This fixes broken link to Eclipse implementation of Jakarta Activation 1.2.2 CI at https://jakarta.ee/specifications/activation/1.2/