### PR TITLE
Updated link to an archived version of Glassfish for Transactions 2.0 as the current link returns 404

### DIFF
--- a/transactions/2.0/_index.md
+++ b/transactions/2.0/_index.md
@@ -17,7 +17,7 @@ Jakarta Transactions - Need scope statement
 
 # Compatible Implementations
 
-* [Eclipse Glassfish 6.0.0-SNAPSHOT-2020-10-04](https://download.eclipse.org/ee4j/glassfish/weekly/glassfish-6.0.0-SNAPSHOT-2020-10-04.zip)
+* [Eclipse Glassfish 6.0.0-SNAPSHOT-2020-10-04](https://github.com/eclipse-ee4j/glassfish/releases/download/6.0.0-M3-2020-10-04/glassfish-6.0.0-M3-2020-10-04.zip)
 
 # Ballots
 


### PR DESCRIPTION
Please see https://github.com/eclipse-ee4j/jta-api/issues/183#issuecomment-725408793