### PR TITLE
Fix JSONP maven coordinates label

### DIFF
--- a/jsonp/2.0/_index.md
+++ b/jsonp/2.0/_index.md
@@ -11,7 +11,7 @@ querying JSON documents.
 * [Jakarta JSON Processing 2.0 Javadoc](./apidocs)
 * [Jakarta JSON Processing 2.0 TCK](https://download.eclipse.org/jakartaee/jsonp/2.0/jakarta-jsonp-tck-2.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonp/2.0/jakarta-jsonp-tck-2.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/jsonp/2.0/jakarta-jsonp-tck-2.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
-  * [jakarta.jsonp:jakarta.jsonp-api:jar:2.0.0](https://search.maven.org/artifact/jakarta.json/jakarta.json-api/2.0.0/jar)
+  * [jakarta.json:jakarta.json-api:jar:2.0.0](https://search.maven.org/artifact/jakarta.json/jakarta.json-api/2.0.0/jar)
 
 # Compatible Implementations
 


### PR DESCRIPTION
The link to Maven central is actually good.

Signed-off-by: Jean-Louis Monteiro <jlmonteiro@tomitribe.com>
