### PR TITLE
Platform TCK 9.0.1 update with excludes for accepted TCK challenges https://github.com/eclipse-ee4j/servlet-api/issues/385 + https://github.com/eclipse-ee4j/servlet-api/issues/378

### DIFF
--- a/platform/9/_index.md
+++ b/platform/9/_index.md
@@ -10,7 +10,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 9 Specification Document](./jakarta-platform-spec-9.pdf) (PDF)
 * [Jakarta EE Platform 9 Specification Document](./jakarta-platform-spec-9.html) (HTML)
 * [Jakarta EE Platform 9 Javadoc](./apidocs)
-* [Jakarta EE Platform 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.0.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta EE Platform 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.1.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:9.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/9.0.0/jar)
 


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

## Platform 9.0 TCK update 
- [x] The tracking issue representing this update:
  Tracking specifications issue https://github.com/jakartaee/specifications/issues/321
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
      https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/promoted/jakarta-jakartaeetck-9.0.1.zip

