### PR TITLE
Update Platform TCK 9.0.2 + Jakarta RESTful Web Services 3.0.1 for TCK challenge 

### DIFF
--- a/platform/9/_index.md
+++ b/platform/9/_index.md
@@ -10,7 +10,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 9 Specification Document](./jakarta-platform-spec-9.pdf) (PDF)
 * [Jakarta EE Platform 9 Specification Document](./jakarta-platform-spec-9.html) (HTML)
 * [Jakarta EE Platform 9 Javadoc](./apidocs)
-* [Jakarta EE Platform 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.1.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta EE Platform 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:9.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/9.0.0/jar)
 

--- a/restful-ws/3.0/_index.md
+++ b/restful-ws/3.0/_index.md
@@ -11,7 +11,7 @@ following the Representational State Transfer (REST) architectural pattern.
 * [Jakarta RESTful Web Services 3.0 Specification Document](./jakarta-restful-ws-spec-3.0.pdf) (PDF)
 * [Jakarta RESTful Web Services 3.0 Specification Document](./jakarta-restful-ws-spec-3.0.html) (HTML)
 * [Jakarta RESTful Web Services 3.0 Javadoc](./apidocs)
-* [Jakarta RESTful Web Services 3.0 TCK](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.0.zip)([sig](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta RESTful Web Services 3.0 TCK](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.1.zip)([sig](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.jaxrs:jakarta.jaxrs-api:jar:3.0.0](https://search.maven.org/artifact/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/jar)
 

--- a/webprofile/9/_index.md
+++ b/webprofile/9/_index.md
@@ -10,7 +10,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta Web Profile 9 Specification Document](./jakarta-webprofile-spec-9.pdf) (PDF)
 * [Jakarta Web Profile 9 Specification Document](./jakarta-webprofile-spec-9.html) (HTML)
 * [Jakarta Web Profile 9 Javadoc](./apidocs)
-* [Jakarta Web Profile 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.0.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Web Profile 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.webprofile-api:jar:9.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/9.0.0/jar)
   


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

## Jakarta RESTful Web Services 3.0 TCK update 
- [x] The tracking issue representing this update:
  Tracking specifications issue https://github.com/jakartaee/specifications/issues/328
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/promoted/jakarta-restful-ws-tck-3.0.1.zip

## Jakarta Platform TCK 9 TCK update 
- [x] The tracking issue representing this update:
  Tracking specifications issue https://github.com/jakartaee/specifications/issues/328
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/promoted/jakarta-jakartaeetck-9.0.2.zip  



