### PR TITLE
Update Compatible Impl references

### DIFF
--- a/platform/8/_index.md
+++ b/platform/8/_index.md
@@ -11,6 +11,12 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/8.0.0/jar)
+* Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
+  * [Eclipse Glassfish 5.1](https://projects.eclipse.org/projects/ee4j.glassfish/downloads)
+
+# Compatible Implementations
+
+* [Jakarta EE 8 Compatible Implementations](https://jakarta.ee/compatibility/#tab-8)
 
 # Ballots
 
@@ -31,7 +37,3 @@ The Specification Committee Ballot concluded successfully on 2019-09-09 with the
 |Committer Members      |   +1    |         |          |
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg00534.html)
-
-# Compatible Implementations
-
-* [Eclipse Glassfish 5.1](https://projects.eclipse.org/projects/ee4j.glassfish/downloads)

--- a/platform/8/_index.md
+++ b/platform/8/_index.md
@@ -15,7 +15,6 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
   * [Eclipse Glassfish 5.1](https://projects.eclipse.org/projects/ee4j.glassfish/downloads)
 
 # Compatible Implementations
-
 * [Jakarta EE 8 Compatible Implementations](https://jakarta.ee/compatibility/#tab-8)
 
 # Ballots

--- a/platform/9.1/_index.md
+++ b/platform/9.1/_index.md
@@ -20,7 +20,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE 9.1 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1#jakarta-ee-9.1-schedule)
 
 # Compatible Implementations
-* * [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
+* [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
 
 # Ballots
 

--- a/platform/9.1/_index.md
+++ b/platform/9.1/_index.md
@@ -13,12 +13,14 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 9.1 TCK](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip)([sig](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:9.1.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/9.1.0/jar)
+* Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
+  * [Eclipse Glassfish x.y.z]()
 
 # Jakarta EE 9.1 Schedule
 * [Jakarta EE 9.1 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1#jakarta-ee-9.1-schedule)
 
 # Compatible Implementations
-* [Eclipse Glassfish 6.x]()
+* * [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
 
 # Ballots
 

--- a/platform/9/_index.md
+++ b/platform/9/_index.md
@@ -13,12 +13,14 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE Platform 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:9.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/9.0.0/jar)
-
+* Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
+  * [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
+  
 # Jakarta EE 9 Schedule
 * [Jakarta EE 9 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)
 
 # Compatible Implementations
-* [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
+* [Jakarta EE 9 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9)
 
 # Ballots
 

--- a/webprofile/8/_index.md
+++ b/webprofile/8/_index.md
@@ -15,7 +15,6 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
   * [Eclipse Glassfish 5.1](https://projects.eclipse.org/projects/ee4j.glassfish/downloads)
 
 # Compatible Implementations
-
 * [Jakarta EE 8 Compatible Implementations](https://jakarta.ee/compatibility/#tab-8)
 
 # Ballots

--- a/webprofile/8/_index.md
+++ b/webprofile/8/_index.md
@@ -11,6 +11,12 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta EE Web Profile 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-web-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/8.0.0/jar)
+* Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
+  * [Eclipse Glassfish 5.1](https://projects.eclipse.org/projects/ee4j.glassfish/downloads)
+
+# Compatible Implementations
+
+* [Jakarta EE 8 Compatible Implementations](https://jakarta.ee/compatibility/#tab-8)
 
 # Ballots
 
@@ -31,7 +37,3 @@ The Specification Committee Ballot concluded successfully on 2019-09-09 with the
 |Committer Members      |   +1    |         |          |
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg00533.html)
-
-# Compatible Implementations
-
-* [Eclipse Glassfish 5.1](https://projects.eclipse.org/projects/ee4j.glassfish/downloads)

--- a/webprofile/9.1/_index.md
+++ b/webprofile/9.1/_index.md
@@ -13,6 +13,9 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta Web Profile 9.1 TCK](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip)([sig](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.webprofile-api:jar:9.1.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/9.1.0/jar)
+* Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
+  * [Eclipse Glassfish x.y.z]()
+
   
 # Jakarta EE 9.1 Schedule
 
@@ -20,7 +23,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 
 # Compatible Implementations
 
-* [Eclipse Glassfish x.y.z]()
+* [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
 
 # Ballots
 

--- a/webprofile/9.1/_index.md
+++ b/webprofile/9.1/_index.md
@@ -15,14 +15,11 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
   * [jakarta.platform:jakarta.webprofile-api:jar:9.1.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/9.1.0/jar)
 * Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
   * [Eclipse Glassfish x.y.z]()
-
   
 # Jakarta EE 9.1 Schedule
-
 * [Jakarta EE 9.1 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1#jakarta-ee-9.1-schedule)
 
 # Compatible Implementations
-
 * [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
 
 # Ballots

--- a/webprofile/9/_index.md
+++ b/webprofile/9/_index.md
@@ -13,15 +13,15 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta Web Profile 9 TCK](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip)([sig](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9/jakarta-jakartaeetck-9.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.webprofile-api:jar:9.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/9.0.0/jar)
-  
+* Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
+  * [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
+    
 # Jakarta EE 9 Schedule
-
-* [Jakarta EE 9 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)
+  * [Jakarta EE 9 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)
 
 # Compatible Implementations
-
-* [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.0.0-RC2.zip)
-
+  * [Jakarta EE 9 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9)
+  
 # Ballots
 
 ## Plan Review

--- a/webprofile/9/_index.md
+++ b/webprofile/9/_index.md
@@ -17,10 +17,10 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
   * [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
     
 # Jakarta EE 9 Schedule
-  * [Jakarta EE 9 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)
+* [Jakarta EE 9 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)
 
 # Compatible Implementations
-  * [Jakarta EE 9 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9)
+* [Jakarta EE 9 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9)
   
 # Ballots
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Per the Spec Committee call today and the recent decision to list the CI used for Ratification in the top matter of the page, I have updated the _index.md files for Jakarta EE 8, 9, and 9.1.  Besides the CI Ratification message, we also decided to just reference the official Compatible Products page for the Platform and Web Profile.