### PR TITLE
fix proxy loop within netlify

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,3 +71,6 @@ for F in $FILES; do
   fi
 done
 echo "Done!"
+
+echo -e "Step 7: Remove jakarta.ee _redirect file."
+rm ../static/_redirects 


### PR DESCRIPTION
I recently created a proxy rule so that we can serve specification updates in real-time instead of once a day. However, when this went live, we started to see a 404 on the specifications section.

After a bit of head-scratching, I believe that the problem is simply that my proxy rule for jakarta.ee is making its way to the specifications repo which is causing a loop that netlify is blocking.

This PR simply removes that _redirect file from jakarta.ee since it's not needed here.