### PR TITLE
fix the links for the 9.1 Compatible Implementations page

### DIFF
--- a/platform/9.1/_index.md
+++ b/platform/9.1/_index.md
@@ -26,7 +26,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * [Jakarta EE 9.1 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1#jakarta-ee-9.1-schedule)
 
 # Compatible Implementations
-* [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
+* [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9_1)
 
 # Ballots
 

--- a/webprofile/9.1/_index.md
+++ b/webprofile/9.1/_index.md
@@ -26,7 +26,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta EE 9.1 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1#jakarta-ee-9.1-schedule)
 
 # Compatible Implementations
-* [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9.1)
+* [Jakarta EE 9.1 Compatible Implementations](https://jakarta.ee/compatibility/#tab-9_1)
 
 # Ballots
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Looks like the new tab for the 9.1 Compatible Implementations page used an underscore (_) instead of a period (.)...