### PR TITLE
JDK 11 TCK links 

### DIFF
--- a/activation/2.0/_index.md
+++ b/activation/2.0/_index.md
@@ -14,9 +14,10 @@ appropriate bean to perform the operation(s).
 * [Jakarta Activation 2.0 Specification Document](./jakarta-activation-spec-2.0.html) (HTML)
 * [Jakarta Activation 2.0 Javadoc](./apidocs)
 * [Jakarta Activation 2.0 TCK](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.0.zip)
-( [sig](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.0.zip.sig),
+([sig](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.0.zip.sig),
 [sha](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.0.zip.sha256),
-[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub) )
+[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+    * Adds JDK 11 support [Jakarta Activation 2.0.1 TCK](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/activation/2.0/jakarta-activation-tck-2.0.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.activation:jakarta.activation-api:jar:2.0.1](https://search.maven.org/artifact/jakarta.activation/jakarta.activation-api/2.0.1/jar)
 * [Change Log](./changelog)

--- a/mail/2.0/_index.md
+++ b/mail/2.0/_index.md
@@ -11,7 +11,8 @@ Jakarta Mail defines a platform-independent and protocol-independent framework t
 * [Jakarta Mail 2.0 Specification Document](./jakarta-mail-spec-2.0.pdf) (PDF)
 * [Jakarta Mail 2.0 Specification Document](./jakarta-mail-spec-2.0.html) (HTML)
 * [Jakarta Mail 2.0 Javadoc](./apidocs)
-* [Jakarta Mail 2.0 TCK](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Mail 2.0 TCK](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * Adds JDK 11 Support [Jakarta Mail 2.0.1 TCK](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/mail/2.0/jakarta-mail-tck-2.0.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.mail:jakarta.mail-api:jar:2.0.1](https://search.maven.org/artifact/jakarta.mail/jakarta.mail-api/2.0.1/jar)
 * [Change Log](./changelog)

--- a/xml-binding/3.0/_index.md
+++ b/xml-binding/3.0/_index.md
@@ -12,7 +12,8 @@ between XML documents and Java objects.
 * [Jakarta XML Binding 3.0 Specification Document](./jakarta-xml-binding-spec-3.0.html) (HTML)
 * [Jakarta XML Binding 3.0 Javadoc](./apidocs)
 * [Jakarta XML Binding 3.0 XML Schema](https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd)
-* [Jakarta XML Binding 3.0 TCK](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta XML Binding 3.0 TCK](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * Adds JDK 11 Support [Jakarta XML Binding 3.0.1 TCK](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/xml-binding/3.0/jakarta-xml-binding-tck-3.0.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1](https://search.maven.org/artifact/jakarta.xml.bind/jakarta.xml.bind-api/3.0.1/jar)
 * [Change Log](./changelog)


### PR DESCRIPTION
Add JDK 11 compatible TCK links for Activation (2.0.1), Mail (2.0.1), and XML Binding (3.0.1)

These TCKs are already promoted to the Spec. download. For details, see each of: [Activation](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/145/), [Mail](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/146/), [XML Binding](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/147/)

Signed-off-by: Ed Bratt <ed.bratt@oracle.com>
