### PR TITLE
Correct name for Jakarta Faces

### DIFF
--- a/faces/_index.md
+++ b/faces/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Jakarta Server Faces"
-summary: "Jakarta Server Faces defines an MVC framework for building user interfaces for web applications, 
+title: "Jakarta Faces"
+summary: "Jakarta Faces defines an MVC framework for building user interfaces for web applications, 
 including UI components, state management, event handing, input validation, page navigation, and 
 support for internationalization and accessibility."
 #<!--.................0123456789.123456789.123456789.123456789.123456789.123456789-->


### PR DESCRIPTION
The name on the overview pages for Jakarta Faces is not correct. It still says "Jakarta Server Faces", but this should be just "Jakarta Faces".