### PR TITLE
Corrected broken links on _index.md

### DIFF
--- a/servlet/6.0/_index.md
+++ b/servlet/6.0/_index.md
@@ -7,7 +7,7 @@ Jakarta Servlet defines a server-side API for handling HTTP requests and respons
 
 * [Jakarta Servlet 6.0 Release Record](https://projects.eclipse.org/projects/ee4j.servlet/releases/6.0)
   * [Jakarta EE Platform 10 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10ReleasePlan)
-* [Jakarta Servlet 6.0 Specification Document] (./jakarta-servlet-spec-6.0.pdf) (PDF)
+* [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.pdf) (PDF)
 * [Jakarta Servlet 6.0 Specification Document] (./jakarta-servlet-spec-6.0.html) (HTML)
 * Jakarta Servlet 6.0 Javadoc(./apidocs)
 * [Jakarta Servlet 6.0.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))

--- a/servlet/6.0/_index.md
+++ b/servlet/6.0/_index.md
@@ -8,8 +8,8 @@ Jakarta Servlet defines a server-side API for handling HTTP requests and respons
 * [Jakarta Servlet 6.0 Release Record](https://projects.eclipse.org/projects/ee4j.servlet/releases/6.0)
   * [Jakarta EE Platform 10 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10ReleasePlan)
 * [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.pdf) (PDF)
-* [Jakarta Servlet 6.0 Specification Document] (./jakarta-servlet-spec-6.0.html) (HTML)
-* Jakarta Servlet 6.0 Javadoc(./apidocs)
+* [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.html) (HTML)
+* [Jakarta Servlet 6.0 Javadoc](./apidocs)
 * [Jakarta Servlet 6.0.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * XML Schema
   * web-app_6_0.xsd


### PR DESCRIPTION
_index.md file had broken links to javadocs, PDF and HTML versions of the spec