### PR TITLE
Update for Jakarta Batch 2.1.1 Service Release

### DIFF
--- a/batch/2.1/_index.md
+++ b/batch/2.1/_index.md
@@ -18,7 +18,7 @@ This release requires Java SE 11 or newer (aligned with Jakarta EE 10).
 * [Jakarta Batch 2.1 Specification Document](./jakarta-batch-spec-2.1.pdf) (PDF)
 * [Jakarta Batch 2.1 Specification Document](./jakarta-batch-spec-2.1.html) (HTML)
 * [Jakarta Batch 2.1 Javadoc](./apidocs)
-* [Jakarta Batch 2.1 TCK](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta Batch 2.1 TCK](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip) ([sig](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 
 * Maven coordinates
   * [jakarta.batch:jakarta.batch-api:jar:2.1.0](https://search.maven.org/artifact/jakarta.batch/jakarta.batch-api/2.1.0/jar)

--- a/batch/2.1/changelog.md
+++ b/batch/2.1/changelog.md
@@ -1,0 +1,17 @@
+---
+title: "Change Log"
+date: 2022-06-06
+summary: "Release for Jakarta EE 10"
+---
+
+### CHANGES IN THE 2.1.1 RELEASE
+
+* Addressed TCK challenges:
+  * https://github.com/eclipse-ee4j/batch-tck/issues/51 - Fixed by documenting the workaround in TCK Reference Guide. Opened new enhancement issue to hopefully improve this area in a future release.
+  * https://github.com/eclipse-ee4j/batch-tck/issues/49 - Fixed by adjusting the test application to allow for multiple ways of implementations setting the correct step exit status.   This assumes that any implementation passing the earlier 2.1.0 TCK will also pass with this modifications (and this fact was confirmed via testing).
+
+* Improved TCK runner parent POM to allow easier use of the reporting module:  https://github.com/eclipse-ee4j/batch-tck/issues/48
+
+### CHANGES IN THE 2.1.0 RELEASE
+
+* initial release of Jakarta Batch 2.1.0


### PR DESCRIPTION
## Specification Service Release PR template
When creating a service release, create PRs with the content defined as follows.

Include the following in the PR:
- [X] The URL of the Eclipse Project release record:
https://projects.eclipse.org/projects/ee4j.batch/releases/2.1.1
- [X] The URL of the OSSRH staging repository for the api, javadoc:
N/A
- [X] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
https://download.eclipse.org/jakartabatch/tck/eftl/jakarta.batch.official.tck-2.1.1.zip
- [X] The URL of the compatibility certification request (CCR) issue:
  Reusing earlier CCR: https://github.com/eclipse-ee4j/batch-api/issues/197 - we will include a comment noting this impl has been validated against the new v2.1.1 TCK
- [X] Specification JavaDoc in the `wombat/x.y/apidocs` directory.
- N/A
- [X] Changelog file at this location describing service release updates, `wombat/x.y/changelog`.
- [X] Update `wombat/x.y/_index.md` accordingly.
- [X] Start service release review by emailing [Specification Committee](https://accounts.eclipse.org/mailing-list/jakarta.ee-spec) and referencing this PR.
https://www.eclipse.org/lists/jakarta.ee-spec/msg02626.html

Note: Specifications themselves do not have service releases.  Only the associated API (limited to JavaDoc updates), JavaDoc, and TCK artifacts can have service releases.  Thus, the Specification version does not use the third digit -- only the `x.y` version is used in the Specification directory structure.
 
@scottmarlow can you please take a look before I email the Specification Committee?  Let me ping @starksm64 too to take a look.  Thank you.

Thank you !


## UPDATE after reading more

In my reading of it, the service release process doesn't really clarify the case where you are only updating a TCK but not the API/Javadoc or spec... so I'm interested to hear what all you think is required here.  E.g. we don't need to produce a Maven release of the API at v2.1.1 just to match this service release do we?  Thanks.