### PR TITLE
Update for Jakarta Batch 2.1.1 (API JAR, Maven-only) release 

### DIFF
--- a/batch/2.1/_index.md
+++ b/batch/2.1/_index.md
@@ -21,7 +21,7 @@ This release requires Java SE 11 or newer (aligned with Jakarta EE 10).
 * [Jakarta Batch 2.1 TCK](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip) ([sig](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 
 * Maven coordinates
-  * [jakarta.batch:jakarta.batch-api:jar:2.1.0](https://search.maven.org/artifact/jakarta.batch/jakarta.batch-api/2.1.0/jar)
+  * [jakarta.batch:jakarta.batch-api:jar:2.1.1](https://search.maven.org/artifact/jakarta.batch/jakarta.batch-api/2.1.1/jar)
 
 * Schemas
   * [XML Schema for the Jakarta Batch artifacts XML file (batch.xml)](https://jakarta.ee/xml/ns/jakartaee/batchXML_2_0.xsd)

--- a/batch/2.1/changelog.md
+++ b/batch/2.1/changelog.md
@@ -1,17 +1,29 @@
 ---
 title: "Change Log"
-date: 2022-06-06
+date: 2022-06-23
 summary: "Release for Jakarta EE 10"
 ---
 
-### CHANGES IN THE 2.1.1 RELEASE
+# CHANGES IN THE 2.1.1 API 
 
-* Addressed TCK challenges:
-  * https://github.com/eclipse-ee4j/batch-tck/issues/51 - Fixed by documenting the workaround in TCK Reference Guide. Opened new enhancement issue to hopefully improve this area in a future release.
-  * https://github.com/eclipse-ee4j/batch-tck/issues/49 - Fixed by adjusting the test application to allow for multiple ways of implementations setting the correct step exit status.   This assumes that any implementation passing the earlier 2.1.0 TCK will also pass with this modifications (and this fact was confirmed via testing).
+This change did not impact the "specification" aspect of the API, e.g. the Javadoc.  Rather, it only related to the JAR manifest (OSGi bundle manifest) of the API JAR maintained by the Jakarta Batch specification & API project within the https://github.com/eclipse-ee4j/batch-api repository and released to Maven Central.  Still, we note the change here for the record.
 
+## Bug Fix:
+* https://github.com/eclipse-ee4j/batch-api/issues/201
+  * Fixed incorrect version in OSGi bundle manifest
+
+# CHANGES IN THE 2.1.1 TCK
+
+## Addressed TCK challenges:
+* https://github.com/eclipse-ee4j/batch-tck/issues/51
+  * Fixed by documenting the workaround in TCK Reference Guide. Opened new enhancement issue to hopefully improve this area in a future release.
+* https://github.com/eclipse-ee4j/batch-tck/issues/49 
+  * Fixed by adjusting the test application to allow for multiple ways of implementations setting the correct step exit status.   This assumes that any implementation passing the earlier 2.1.0 TCK will also pass with this modifications (and this fact was confirmed via testing).
+
+## Other fixes:
 * Improved TCK runner parent POM to allow easier use of the reporting module:  https://github.com/eclipse-ee4j/batch-tck/issues/48
 
-### CHANGES IN THE 2.1.0 RELEASE
 
-* initial release of Jakarta Batch 2.1.0
+# CHANGES IN THE 2.1.0 RELEASE
+
+* initial release of Jakarta Batch 2.1.0: Specification, API, TCK


### PR DESCRIPTION
This PR has two aspects:

## 1. Jakarta Batch 2.1 spec webpage

The Jakarta Batch 2.1 spec page: https://jakarta.ee/specifications/batch/2.1/ will be updated to point to the latest API JAR Maven coordinates.

This is of no real value from a specification point of view.   It is just motivated by a general desire to keep things up to date.  We link to specific Maven API JAR coordinates, might as well use the latest.


## 2. Internal Changelog

Though I'm not sure this is externally visible, those working within this **specifications** repository will be able to read the history of the 2.1.1 API Maven release vs. the 2.1.1 TCK Maven release.   It seems this might be helpful to someone.  

Note there is NOT going to be an Eclipse ee4j.batch 2.1.1 release (at https://projects.eclipse.org/projects/ee4j.batch/releases)