### PR TITLE
Move release goals content out of "Compatible Implementation" section

### DIFF
--- a/cdi/4.0/_index.md
+++ b/cdi/4.0/_index.md
@@ -6,6 +6,21 @@ summary: "Release for Jakarta EE 10"
 
 Jakarta Contexts Dependency Injection specifies a means for obtaining objects in such a way as to maximize reusability, testability and maintainability compared to traditional approaches such as constructors, factories, and service locators (e.g., JNDI).
 
+The Jakarta Contexts and Dependency Injection 4.0 goals for this release are:
+
+* Split the existing 3.0 specification into pieces that separate out requirements based on the target runtime container support; Java SE, Jakarta Servlet, Jakarta Message Service, etc.
+* Breakup the TCK to separate out the concers along the lines of the target runtime requirements as outlined in 1.
+* Introduce a new CDI-lite specification that targets supporting build time compliation of applications.
+* Java SE version will be aligned with the Core profile requirements regarding Java SE versions.
+* Consider addressing open issues:
+    * [Executable methods](https://github.com/eclipse-ee4j/cdi/issues/460)
+    * [Removal of deprecated bits](https://github.com/eclipse-ee4j/cdi/issues/472)
+    * [Improve constructor injection](https://github.com/eclipse-ee4j/cdi/issues/464)
+    * [AFTER_SUCCESS Observers and Events fired from within EntityListeners](https://github.com/eclipse-ee4j/cdi/issues/467)
+    * [Add methods to BeanConfigurator for applying decorators](https://github.com/eclipse-ee4j/cdi/issues/459)
+    * [All issues with a Lite label](https://github.com/eclipse-ee4j/cdi/issues?q=is%3Aissue+label%3ALite)
+
+
 * [Jakarta Contexts Dependency Injection 4.0 Release Record](https://projects.eclipse.org/projects/ee4j.cdi/releases/4.0)
 * [Jakarta EE Platform 10 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10ReleasePlan)
 * [Jakarta Contexts Dependency Injection 4.0 Specification Document](./jakarta-cdi-spec-4.0.pdf) (PDF)
@@ -25,22 +40,6 @@ Jakarta Contexts Dependency Injection specifies a means for obtaining objects in
 # Compatible Implementations
 
 * [Weld 5.0.0.SP2](https://weld.cdi-spec.org/download/)
-
-The Jakarta Contexts and Dependency Injection 4.0 goals for this release are:
-
-* Split the existing 3.0 specification into pieces that separate out requirements based on the target runtime container support; Java SE, Jakarta Servlet, Jakarta Message Service, etc.
-* Breakup the TCK to separate out the concers along the lines of the target runtime requirements as outlined in 1.
-* Introduce a new CDI-lite specification that targets supporting build time compliation of applications.
-* Java SE version will be aligned with the Core profile requirements regarding Java SE versions.
-* Consider addressing open issues:
-    * [Executable methods](https://github.com/eclipse-ee4j/cdi/issues/460)
-    * [Removal of deprecated bits](https://github.com/eclipse-ee4j/cdi/issues/472)
-    * [Improve constructor injection](https://github.com/eclipse-ee4j/cdi/issues/464)
-    * [AFTER_SUCCESS Observers and Events fired from within EntityListeners](https://github.com/eclipse-ee4j/cdi/issues/467)
-    * [Add methods to BeanConfigurator for applying decorators](https://github.com/eclipse-ee4j/cdi/issues/459)
-    * [All issues with a Lite label](https://github.com/eclipse-ee4j/cdi/issues?q=is%3Aissue+label%3ALite)
-
-
 
 # Ballots
 


### PR DESCRIPTION
I noticed the details around the release plan / goals of the release were in the Compatible Implementation section.  This PR moves that content to the top of the page where release goals should be.