### PR TITLE
Apply revised templates for Concurrency 3.0 and SOAP 3.0

### DIFF
--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta Concurrency 3.0"
 date: 2022-04-27
-summary: "Jakarta EE 10 Release"
+summary: "Concurrency 3.0 for Jakarta EE 10 Release"
 ---
 <!-- Please provide a short description of the specification. -->
 <!-- Typically this will not change cfrom version to version. -->
@@ -20,7 +20,7 @@ This release adds the following
 * Modernization of the Trigger mechanism with time zone support
 * Propagation of third party context types (See Chapter 4, *Thread Context Providers*)
 * Resource definition annotations and corresponding deployment descriptor elements
-### Incompatibilities
+###  Removals, deprecations or backwards incompatible changes
 
 ### Minimum Java SE Version
 * This release requires Java SE 11 or higher

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -39,7 +39,8 @@ This release adds the following
   * Signature tests are included with the TCK and run automatically as part of it
 * Maven coordinates
   * [jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0](https://search.maven.org/artifact/jakarta.enterprise.concurrent/jakarta.enterprise.concurrent-api/3.0.0/jar)
-
+* Compatible Implementation used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification)
+    * [Open Liberty 22.0.0.5-beta](https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/beta/22.0.0.5-beta/openliberty-22.0.0.5-beta.zip)
 
 # Compatible Implementations
 

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -23,7 +23,7 @@ This release adds the following
 ###  Removals, deprecations or backwards incompatible changes
 
 ### Minimum Java SE Version
-* This release requires Java SE 11 or higher
+* **Java SE 11 or higher**
 
 # Details
 

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta Concurrency 3.0"
 date: 2022-04-27
-summary: "Concurrency 3.0 for Jakarta EE 10 Release"
+summary: "Jakarta EE 10 Release"
 ---
 <!-- Please provide a short description of the specification. -->
 <!-- Typically this will not change cfrom version to version. -->

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -3,22 +3,29 @@ title: "Jakarta Concurrency 3.0"
 date: 2022-04-27
 summary: "Jakarta EE 10 Release"
 ---
-Jakarta Concurrency provides a specification for using concurrency from application components without compromising container integrity while still preserving the Jakarta EE platform's fundamental benefits.
+<!-- Please provide a short description of the specification. -->
+<!-- Typically this will not change cfrom version to version. -->
 
+Jakarta Concurrency provides a specification for using concurrency from application components without compromising container integrity while still preserving the Jakarta EE platform's fundamental benefits. 
 
-# Plan
+<!-- Please describe the high-level changes made to Jakarta Wombat 1.0. --> 
+<!-- The intent is for the first two sections to be an executive summary in the range of 300 to 800 characters. -->
+<!-- Links can accompany the executive summary, but cannot substitute for an executive summary. -->
 
-Jakarta Concurrency 3.0 contains the following features:
-
-* Asynchronous methods
-* Context-aware completion stages and completable futures
+### New Features
+This release adds the following
+* Asynchronous methods (See Chapter 5, *Asynchronous Methods*)
+* Context-aware completion stages and Completable Futures
 * Context propagation to parallel streams operations
-* Modernization of the Trigger mechanism and Cron support
-* Propagation of third party context types
-* Resource definition annotations
+* Modernization of the Trigger mechanism with time zone support
+* Propagation of third party context types (See Chapter 4, *Thread Context Providers*)
+* Resource definition annotations and corresponding deployment descriptor elements
+### Incompatibilities
 
+### Minimum Java SE Version
+* This release requires Java SE 11 or higher
 
-# Release Information
+# Details
 
 * [Jakarta Concurrency 3.0 Release Record](https://projects.eclipse.org/projects/ee4j.cu/releases/3.0.0)
   * [Jakarta Concurrency 3.0 Release Plan](https://projects.eclipse.org/projects/ee4j.cu/releases/3.0/plan)
@@ -26,11 +33,9 @@ Jakarta Concurrency 3.0 contains the following features:
 * [Jakarta Concurrency 3.0 Specification Document](./jakarta-concurrency-spec-3.0.pdf) (PDF)
 * [Jakarta Concurrency 3.0 Specification Document](./jakarta-concurrency-spec-3.0.html) (HTML)
 * [Jakarta Concurrency 3.0 Javadoc](./apidocs)
-
-
 * [Jakarta Concurrency 3.0 TCK](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.0.zip), ([sig](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.0.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
-   * First service release [Jakarta Concurrency 3.0 TCK](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.1.zip), ([sig](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.1.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
-   * Second service release [Jakarta Concurrency 3.0 TCK](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip), ([sig](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip.sig), [sha](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * First service release [Jakarta Concurrency 3.0.1 TCK](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.1.zip), ([sig](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.1.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * Second service release [Jakarta Concurrency 3.0.2 TCK](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip), ([sig](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip.sig), [sha](https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
   * Signature tests are included with the TCK and run automatically as part of it
 * Maven coordinates
   * [jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0](https://search.maven.org/artifact/jakarta.enterprise.concurrent/jakarta.enterprise.concurrent-api/3.0.0/jar)

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -52,19 +52,22 @@ This release adds the following
 
 The Specification Committee Ballot for Concurrency 3.0 successfully concluded on May 11, 2022. The results were as follows:
 
-| Representative                     | Representative for: | Vote   |
-|------------------------------------|---------------------|--------|
-| Kenji Kazumura                     | Fujitsu             | +1     |
-| Tom Watson, Emily Jiang            | IBM                 | +1     |
-| Ed Bratt, Dmitry Kornilov          | Oracle              | +1     |
-| Andrew Pielage                     | Payara              | +1     |
-| David Blevins, Jean-Louis Monteiro | Tomitribe           | +1     |
-| Ivar Grimstad                      | EE4J PMC            | +1     |
-| Marcelo Ancelmo, Martijn Verburg   | Participant Members | +1     |
-| Werner Keil                        | Committer Members   | +1     |
-| Jun Qian                           | Enterprise Members  | +1     |
-| Zhai Luchao                        | Enterprise Members  | +1     |  
-|                                    | **Total**           | **10** |
+
+|Organization                       |  Yes    | No      | Abstain  |
+|-----------------------------------|---------|---------|----------|
+|Fujitsu                            | &check; |         |          |
+|IBM                                | &check; |         |          |
+|Oracle                             | &check; |         |          |
+|Payara                             | &check; |         |          |
+|Tomitribe                          | &check; |         |          |
+|EE4J PMC                           | &check; |         |          |
+|Participant Members                | &check; |         |          |
+|Committer Members                  | &check; |         |          |
+|Enterprise Members (Jun Qian)      | &check; |         |          |
+|Committer Members (Zhai Luchao)    | &check; |         |          |
+
+(10 Yes votes)
+
 
 The ballot was conducted over the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02441.html)
 

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -52,7 +52,6 @@ This release adds the following
 
 The Specification Committee Ballot for Concurrency 3.0 successfully concluded on May 11, 2022. The results were as follows:
 
-
 |Organization                       |  Yes    | No      | Abstain  |
 |-----------------------------------|---------|---------|----------|
 |Fujitsu                            | &check; |         |          |
@@ -65,9 +64,7 @@ The Specification Committee Ballot for Concurrency 3.0 successfully concluded on
 |Committer Members                  | &check; |         |          |
 |Enterprise Members (Jun Qian)      | &check; |         |          |
 |Committer Members (Zhai Luchao)    | &check; |         |          |
-
-(10 Yes votes)
-
+|**Total**                          | **10**  |         |          |
 
 The ballot was conducted over the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02441.html)
 

--- a/concurrency/3.0/_index.md
+++ b/concurrency/3.0/_index.md
@@ -15,7 +15,7 @@ Jakarta Concurrency provides a specification for using concurrency from applicat
 ### New Features
 This release adds the following
 * Asynchronous methods (See Chapter 5, *Asynchronous Methods*)
-* Context-aware completion stages and Completable Futures
+* Context-aware completion stages and completable futures
 * Context propagation to parallel streams operations
 * Modernization of the Trigger mechanism with time zone support
 * Propagation of third party context types (See Chapter 4, *Thread Context Providers*)

--- a/soap-attachments/3.0/_index.md
+++ b/soap-attachments/3.0/_index.md
@@ -25,7 +25,7 @@ and consume messages conforming to the SOAP 1.1, SOAP 1.2, and SOAP Attachments 
 * drops the search through Java SE instalation in the implementation lookup
 
 ### Minimum Java SE Version
-* This release requires Java SE 11 or newer (aligned with Jakarta EE 10).
+* **Java SE 11 or higher**
 
 # Details
 * [Jakarta SOAP Attachments 3.0 Release Record](https://projects.eclipse.org/projects/ee4j.jaxws/releases/3.0-jakarta-soap-attachments)

--- a/soap-attachments/3.0/_index.md
+++ b/soap-attachments/3.0/_index.md
@@ -49,19 +49,20 @@ and consume messages conforming to the SOAP 1.1, SOAP 1.2, and SOAP Attachments 
 
 The Specification Committee Ballot concluded successfully on 2022-03-11 with the following results.
 
-| Representative                     | Representative for: | Vote   |
-|------------------------------------|---------------------|--------|
-| Kenji Kazumura                     | Fujitsu             | +1     |
-| Tom Watson, Emily Jiang            | IBM                 | +1     |
-| Ed Bratt, Dmitry Kornilov          | Oracle              | +1     |
-| Andrew Pielage                     | Payara              | +1     |
-| David Blevins, Jean-Louis Monteiro | Tomitribe           | +1     |
-| Ivar Grimstad                      | EE4J PMC            | +1     |
-| Marcelo Ancelmo, Martijn Verburg   | Participant Members | +1     |
-| Werner Keil                        | Committer Members   | +1     |
-| Jun Qian                           | Enterprise Members  | +1     |
-| Zhai Luchao                        | Enterprise Members  | +1     |  
-|                                    | **Total**           | **10** |
+|Organization                       |  Yes    | No      | Abstain  |
+|-----------------------------------|---------|---------|----------|
+|Fujitsu                            | &check; |         |          |
+|IBM                                | &check; |         |          |
+|Oracle                             | &check; |         |          |
+|Payara                             | &check; |         |          |
+|Tomitribe                          | &check; |         |          |
+|EE4J PMC                           | &check; |         |          |
+|Participant Members                | &check; |         |          |
+|Committer Members                  | &check; |         |          |
+|Enterprise Members (Jun Qian)      | &check; |         |          |
+|Committer Members (Zhai Luchao)    | &check; |         |          |
+
+(10 Yes votes)
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02245.html)
 

--- a/soap-attachments/3.0/_index.md
+++ b/soap-attachments/3.0/_index.md
@@ -61,8 +61,8 @@ The Specification Committee Ballot concluded successfully on 2022-03-11 with the
 |Committer Members                  | &check; |         |          |
 |Enterprise Members (Jun Qian)      | &check; |         |          |
 |Committer Members (Zhai Luchao)    | &check; |         |          |
+|**Total**                          | **10**  |         |          |
 
-(10 Yes votes)
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02245.html)
 

--- a/soap-attachments/3.0/_index.md
+++ b/soap-attachments/3.0/_index.md
@@ -36,6 +36,8 @@ and consume messages conforming to the SOAP 1.1, SOAP 1.2, and SOAP Attachments 
 * [Jakarta SOAP Attachments 3.0 TCK](https://download.eclipse.org/jakartaee/soap-attachments/3.0/jakarta-soap-tck-3.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/soap-attachments/3.0/jakarta-soap-tck-3.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/soap-attachments/3.0/jakarta-soap-tck-3.0.0.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
     * [jakarta.xml.soap:jakarta.xml.soap-api:jar:3.0.0](https://search.maven.org/artifact/jakarta.xml.soap/jakarta.xml.soap-api/3.0.0/jar)
+* Compatible Implementation used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification)
+    * [Eclipse Implementation of Jakarta SOAP with Attachments 3.0.0-M2](https://github.com/eclipse-ee4j/metro-saaj/releases/tag/3.0.0-M2)
 
 # Compatible Implementations
 

--- a/soap-attachments/3.0/_index.md
+++ b/soap-attachments/3.0/_index.md
@@ -6,19 +6,28 @@ summary: "Release for Jakarta EE 10"
 Jakarta SOAP with Attachments defines an API enabling developers to produce
 and consume messages conforming to the SOAP 1.1, SOAP 1.2, and SOAP Attachments Feature.
 
-This release contains following changes:
+<!-- Please describe the high-level changes made to Jakarta Wombat 1.0. --> 
+<!-- The intent is for the first two sections to be an executive summary in the range of 300 to 800 characters. -->
+<!-- Links can accompany the executive summary, but cannot substitute for an executive summary. -->
+
+### New features, enhancements or additions
 
 * adds SOAPEnvelope.createName(String, String): Name method
-* does not allow null arguments in SOAPFault.createFault(String, String)
 * extends SOAPConnection to implement java.io.Autocloseable
 * adds API to allow setting timeouts for set timeout for SOAPConnection.call
-* drops all references to JAXM
-* drops the search through Java SE instalation in the implementation lookup
-* removes deprecated SOAPElementFactory
 * editorial updates and clarifications in the specification
 
-This release requires Java SE 11 or newer (aligned with Jakarta EE 10).
+### Removals, deprecations or backwards incompatible changes
+<!-- List here -->
+* removes deprecated SOAPElementFactory
+* does not allow null arguments in SOAPFault.createFault(String, String)
+* drops all references to JAXM
+* drops the search through Java SE instalation in the implementation lookup
 
+### Minimum Java SE Version
+* This release requires Java SE 11 or newer (aligned with Jakarta EE 10).
+
+# Details
 * [Jakarta SOAP Attachments 3.0 Release Record](https://projects.eclipse.org/projects/ee4j.jaxws/releases/3.0-jakarta-soap-attachments)
     * [Jakarta EE Platform 10 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10ReleasePlan)
 * [Jakarta SOAP Attachments 3.0 Specification Document](./jakarta-soap-spec-3.0.pdf) (PDF)
@@ -57,6 +66,7 @@ The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org
 ## Plan Review
 
 The Specification Committee Ballot concluded successfully on 2021-05-10 with the following results.
+
 | Representative                                 | Representative for: | Vote |
 |------------------------------------------------|---------------------|------|
 | Kenji Kazumura                                 | Fujitsu             |  +1  |


### PR DESCRIPTION
Update for Concurrency 3.0 and SOAP 3.0 pages to add headings as proposed in new [Spec. committee template](https://github.com/jakartaee/specification-committee/blob/master/spec_page_template.md).