### PR TITLE
Update Platform TCK 10.0.1 + Jakarta Servlet TCK 6.0.1 for TCK challenge https://github.com/jakartaee/servlet/issues/472 + https://github.com/jakartaee/servlet/issues/471

### DIFF
--- a/platform/10/_index.md
+++ b/platform/10/_index.md
@@ -32,7 +32,8 @@ Chapter 17)
 * [Jakarta EE Platform 10 Specification Document](./jakarta-platform-spec-10.0.pdf) (PDF)
 * [Jakarta EE Platform 10 Specification Document](./jakarta-platform-spec-10.0.html) (HTML)
 * [Jakarta EE Platform 10 Javadoc](./apidocs)
-* [Jakarta EE Platform 10 TCK](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta EE Platform 10 TCK](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+   * Addresses Servlet Challenge (Issue [#472](https://github.com/eclipse-ee4j/servlet-api/issues/472))  [Jakarta EE Platform 10.0.1 TCK](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:10.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/10.0.0/jar)
 * Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).

--- a/platform/10/_index.md
+++ b/platform/10/_index.md
@@ -32,7 +32,7 @@ Chapter 17)
 * [Jakarta EE Platform 10 Specification Document](./jakarta-platform-spec-10.0.pdf) (PDF)
 * [Jakarta EE Platform 10 Specification Document](./jakarta-platform-spec-10.0.html) (HTML)
 * [Jakarta EE Platform 10 Javadoc](./apidocs)
-* [Jakarta EE Platform 10 TCK](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta EE Platform 10 TCK](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.1.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:10.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/10.0.0/jar)
 * Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).

--- a/servlet/6.0/_index.md
+++ b/servlet/6.0/_index.md
@@ -40,7 +40,7 @@ Jakarta Servlet defines a server-side API for handling HTTP requests and respons
 * [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.pdf) (PDF)
 * [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.html) (HTML)
 * [Jakarta Servlet 6.0 Javadoc](./apidocs)
-* [Jakarta Servlet 6.0.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Servlet 6.0.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * XML Schema
   * web-app_6_0.xsd
   * web-common_6_0.xsd

--- a/servlet/6.0/_index.md
+++ b/servlet/6.0/_index.md
@@ -40,7 +40,8 @@ Jakarta Servlet defines a server-side API for handling HTTP requests and respons
 * [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.pdf) (PDF)
 * [Jakarta Servlet 6.0 Specification Document](./jakarta-servlet-spec-6.0.html) (HTML)
 * [Jakarta Servlet 6.0 Javadoc](./apidocs)
-* [Jakarta Servlet 6.0.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Servlet 6.0.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * Addresses Servlet Challenge (Issue [#472](https://github.com/eclipse-ee4j/servlet-api/issues/472))  [Jakarta Servlet 6.0.1 TCK](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/servlet/6.0/jakarta-servlet-tck-6.0.1.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * XML Schema
   * web-app_6_0.xsd
   * web-common_6_0.xsd


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

## Jakarta Servlet 6.0 TCK update 
- [x] The tracking issue representing this update:
  Tracking specifications issues https://github.com/jakartaee/servlet/issues/472 + https://github.com/jakartaee/servlet/issues/471
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-servlet-tck-6.0.1.zip

## Jakarta Platform 10 TCK update 
- [x] The tracking issue representing this update:
  Tracking specifications issues https://github.com/jakartaee/servlet/issues/472 + https://github.com/jakartaee/servlet/issues/471
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-jakartaeetck-10.0.1.zip




