### PR TITLE
update translations of specifications/platform/10,9.1,8 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /website
 .idea
+_index.md
+_index.zh.md

--- a/platform/10/_index.zh.md
+++ b/platform/10/_index.zh.md
@@ -1,0 +1,69 @@
+---
+title: "Jakarta EE Platform 10 (开发中)"
+date: 2021-08-11
+summary: "Jakarta EE Platform 10 定义了承载 Jakarta EE 应用的标准平台. 查找规范和兼容实现."
+seo_title: "Jakarta EE Platform 10 (开发中) | 承载 Jakarta EE 应用的标准"
+---
+Jakarta EE Platform 定义了承载 Jakarta EE 应用的标准平台.
+
+* [Jakarta EE Platform 10 发布记录](https://projects.eclipse.org/projects/ee4j.jakartaee-platform/releases/10)
+  * [阶段性 Jakarta EE 10 发布计划](https://docs.google.com/document/d/1U24VmTzAfXcn3WBnVcolb8vhZO-Pnk_bit0CKh_d2jM/edit#)
+  * [最终 Jakarta EE Platform 10 发布计划](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10ReleasePlan)
+* [Jakarta EE Platform 10 规范文档](./jakarta-platform-spec-10.pdf) (PDF)
+* [Jakarta EE Platform 10 规范文档](./jakarta-platform-spec-10.html) (HTML)
+* [Jakarta EE Platform 10 Javadoc](./apidocs)
+* [Jakarta EE Platform 10 TCK](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* Maven 坐标
+  * [jakarta.platform:jakarta.jakartaee-api:jar:10.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/10.0.0/jar)
+* 用于 [批准](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification) 的兼容实现.
+  * [待完成]()
+
+# Jakarta EE 10 一览
+* [Jakarta EE 10 一览](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10#jakarta-ee-10-schedule)
+
+# 兼容实现
+* [Jakarta EE 10 兼容实现](https://jakarta.ee/compatibility/#tab-10)
+
+# 投票结果
+
+## 计划评审
+
+**规范委员会** 对此的投票于 2021-08-09 成功完成，结果如下：
+
+| 投票代表		                                 | 投票企业			   |  结果  |
+|------------------------------------------------|---------------------|--------|
+| Kenji Kazumura                                 | Fujitsu             |   +1   |
+| Dan Bandera, Kevin Sutter                      | IBM                 |   +1   |
+| Ed Bratt, Dmitry Kornilov                      | Oracle              |   +1   |
+| Andrew Pielage, Matt Gill                      | Payara              |   +1   |
+| Scott Stark, Mark Little                       | Red Hat             |   +1   |
+| David Blevins, Jean-Louis Monteiro             | Tomitribe           |   +1   |
+| Ivar Grimstad                                  | EE4J PMC            |   +1   |
+| Marcelo Ancelmo, Martijn Verburg               | Participant Members |   +1   |
+| Werner Keil                                    | Committer Members   |   +1   |
+| Jun Qian                                       | Enterprise Members  |   +1   |
+|                                                | Total               | **10** |
+
+投票过程在此处 [jakarta.ee-spec 邮件列表](https://www.eclipse.org/lists/jakarta.ee-spec/msg01927.html).
+
+## 发布评审
+
+<!--
+The Specification Committee Ballot concluded successfully on 2021-05-17 with the following results.
+
+| Representative                                 | Representative for: | Vote |
+|------------------------------------------------|---------------------|------|
+| Kenji Kazumura	                               | Fujitsu	           | +1   |
+| Dan Bandera, Kevin Sutter	                     | IBM	               | +1   |
+| Ed Bratt, Dmitry Kornilov	                     | Oracle	             | +1   |
+| Andrew Pielage, Matt Gill	                     | Payara	             | +1   |
+| Scott Stark, Mark Little	                     | Red Hat	           | +1   |
+| David Blevins, Jean-Louis Monteiro	           | Tomitribe	         | +1   |
+| Ivar Grimstad	                                 | EE4J PMC	           | +1   |
+| Marcelo Ancelmo, Martijn Verburg	             | Participant Members | +1   |
+| Werner Keil	                                   | Committer Members   | +1   |
+| Scott (Congquan) Wang, Jun Qian                | Enterprise Members  | +1   |
+|                                                | Total               | 10   |
+
+The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg01722.html)
+-->

--- a/platform/8/_index.zh.md
+++ b/platform/8/_index.zh.md
@@ -9,7 +9,7 @@ Jakarta EE Platform 定义了承载 Jakarta EE 应用的标准平台.
 * [Jakarta EE Platform 8 规范文档](./platform-spec-8.html) (HTML)
 * [Jakarta EE Platform 8 Javadoc](./apidocs)
 * [Jakarta EE Platform 8 TCK](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/8/jakarta-jakartaeetck-8.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
-* Maven 协同
+* Maven 坐标
   * [jakarta.platform:jakarta.jakartaee-api:jar:8.0.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/8.0.0/jar)
 
 # 投票结果

--- a/platform/9.1/_index.zh.md
+++ b/platform/9.1/_index.zh.md
@@ -1,0 +1,72 @@
+---
+title: "Jakarta EE Platform 9.1"
+date: 2021-05-14
+summary: "Jakarta EE Platform 9.1 定义了承载 Jakarta EE 应用的标准平台. 查找规范和兼容实现."
+seo_title: "Jakarta EE Platform 9.1 | 承载 Jakarta EE 应用的标准"
+---
+Jakarta EE Platform 定义了承载 Jakarta EE 应用的标准平台.
+
+* [Jakarta EE Platform 9.1 发布记录](https://projects.eclipse.org/projects/ee4j.jakartaee-platform/releases/9.1)
+  * [Jakarta EE Platform 9.1 发布计划](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1ReleasePlan)
+* [Jakarta EE Platform 9.1 规范文档](./jakarta-platform-spec-9.1.pdf) (PDF)
+* [Jakarta EE Platform 9.1 规范文档](./jakarta-platform-spec-9.1.html) (HTML)
+* [Jakarta EE Platform 9.1 Javadoc](./apidocs)
+* [Jakarta EE Platform 9.1 TCK](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/platform/9.1/jakarta-jakartaeetck-9.1.0.zip.sha256),[pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* Maven 坐标
+  * [jakarta.platform:jakarta.jakartaee-api:jar:9.1.0](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/9.1.0/jar)
+* 用于 [批准](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification) 的兼容实现.
+  * [Eclipse Glassfish 6.1 RC1 (JDK 11)](https://download.eclipse.org/ee4j/glassfish/glassfish-6.1.0-RC1.zip)
+  * [Eclipse Glassfish 6.0 (JDK 8)](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0.zip)
+  * [ManageFish 6.1.0 (JDK 11)](https://download.managecat.com/6.1.0/managefish-fullprofile-6.1.0.zip)
+  * [OpenLiberty 21.0.0.3-Beta (JDK 11)](https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2021-02-09_1100/openliberty-jakartaee9-21.0.0.3-beta.zip)
+  * [OpenLiberty 21.0.0.3-Beta (JDK 8)](https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2021-02-09_1100/openliberty-jakartaee9-21.0.0.3-beta.zip)
+  * [WildFly Preview 23.0.2.Final (JDK 11)](https://download.jboss.org/wildfly/23.0.2.Final/wildfly-preview-23.0.2.Final.zip)
+  * [WildFly Preview 23.0.2.Final (JDK 8)](https://download.jboss.org/wildfly/23.0.2.Final/wildfly-preview-23.0.2.Final.zip)
+
+# Jakarta EE 9.1 一览
+* [Jakarta EE 9.1 一览](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9.1#jakarta-ee-9.1-schedule)
+
+# 兼容实现
+* [Jakarta EE 9.1 兼容实现](https://jakarta.ee/compatibility/#tab-9_1)
+
+# 投票
+
+## 计划评审
+
+**规范委员会** 对此的投票于 2020-02-10 成功完成，结果如下：
+
+| 投票代表		                                 | 投票企业			   | 结果 |
+|------------------------------------------------|---------------------|------|
+| Kenji Kazumura                                 | Fujitsu             | +1   |
+| Dan Bandera, Kevin Sutter                      | IBM                 | +1   |
+| Ed Bratt, Dmitry Kornilov                      | Oracle              | +1   |
+| Andrew Pielage, Matt Gill                      | Payara              | +1   |
+| Scott Stark, Mark Little                       | Red Hat             | +1   |
+| David Blevins, Jean-Louis Monteiro             | Tomitribe           | +1   |
+| Ivar Grimstad                                  | EE4J PMC            | +1   |
+| Marcelo Ancelmo, Martijn Verburg               | Participant Members | +1   |
+| Werner Keil                                    | Committer Members   | +1   |
+| Scott (Congquan) Wang, Jun Qian                | Enterprise Members  | +1   |
+|                                                | Total               | 10   |
+
+投票过程在此处 [jakarta.ee-spec 邮件列表](https://www.eclipse.org/lists/jakarta.ee-spec/msg01423.html).
+
+## 发布评审
+
+**规范委员会** 对此的投票于 2021-05-17 成功完成，结果如下：
+
+| 投票代表		                                 | 投票企业			   | 结果 |
+|------------------------------------------------|---------------------|------|
+| Kenji Kazumura	                               | Fujitsu	           | +1   |
+| Dan Bandera, Kevin Sutter	                     | IBM	               | +1   |
+| Ed Bratt, Dmitry Kornilov	                     | Oracle	             | +1   |
+| Andrew Pielage, Matt Gill	                     | Payara	             | +1   |
+| Scott Stark, Mark Little	                     | Red Hat	           | +1   |
+| David Blevins, Jean-Louis Monteiro	           | Tomitribe	         | +1   |
+| Ivar Grimstad	                                 | EE4J PMC	           | +1   |
+| Marcelo Ancelmo, Martijn Verburg	             | Participant Members | +1   |
+| Werner Keil	                                   | Committer Members   | +1   |
+| Scott (Congquan) Wang, Jun Qian                | Enterprise Members  | +1   |
+|                                                | Total               | 10   |
+
+投票过程在此处 [jakarta.ee-spec 邮件列表](https://www.eclipse.org/lists/jakarta.ee-spec/msg01722.html)


### PR DESCRIPTION
This will update the Chinese translations of specifications/platform/10,9.1,8.
And to  view the real-time appearance of specifications on jakarta.ee, I put specifications into jakarta.ee/content(but not tracked by jakarta.ee repo), this needs to ignore index files in original  jakarta.ee repo(/content/specifications).
