### PR TITLE
Add the Jakarta EE Compatible logo

### DIFF
--- a/coreprofile/10/_index.md
+++ b/coreprofile/10/_index.md
@@ -39,6 +39,13 @@ The goals for this release were:
   * [WildFly Preview 27.0.0.Alpha1 (JDK 11)](https://github.com/wildfly/wildfly/releases/download/27.0.0.Alpha1/wildfly-preview-27.0.0.Alpha1.zip)
 
 # Compatible Implementations
+
+Compatible Implementations of the Jakarta EE Core Profile are eligible to use the _Jakarta EE Compatible_ logo.
+
+{{< figure src="/images/jakarta/jakarta-ee-compatible-logo-color.svg" alt="Jakarta EE Compatible logo" width="250" >}}
+
+For more information, see [Get Listed](/compatibility/get-listed/)
+
 * [Jakarta EE 10 Core Profile Compatible Implementations](https://jakarta.ee/compatibility/certification/10/)
 
 # Ballots

--- a/platform/10/_index.md
+++ b/platform/10/_index.md
@@ -43,6 +43,13 @@ Chapter 17)
 * [Jakarta EE 10 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10#jakarta-ee-10-schedule)
 
 # Compatible Implementations
+
+Compatible Implementations of the Jakarta EE Platform are eligible to use the _Jakarta EE Compatible_ logo.
+
+{{< figure src="/images/jakarta/jakarta-ee-compatible-logo-color.svg" alt="Jakarta EE Compatible logo" width="250" >}}
+
+For more information, see [Get Listed](/compatibility/get-listed/)
+
 * [Jakarta EE 10 Compatible Implementations](https://jakarta.ee/compatibility/certification/10/)
 
 # Ballots

--- a/webprofile/10/_index.md
+++ b/webprofile/10/_index.md
@@ -35,6 +35,13 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * [Jakarta EE 10 Schedule](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10#jakarta-ee-10-schedule)
 
 # Compatible Implementations
+
+Compatible Implementations of the Jakarta EE Web Profile are eligible to use the _Jakarta EE Compatible_ logo.
+
+{{< figure src="/images/jakarta/jakarta-ee-compatible-logo-color.svg" alt="Jakarta EE Compatible logo" width="250" >}}
+
+For more information, see [Get Listed](/compatibility/get-listed/)
+
 * [Jakarta EE 10 Compatible Implementations](https://jakarta.ee/compatibility/certification/10/)
 
 # Ballots


### PR DESCRIPTION
See #595 for background.

This pull request adds the Jakarta EE Compatible logo to the platform and two profiles.

At least for now, this is experiment to see whether or not it gets rendered correctly. 

Please don't merge until I get a chance to run this past the specification committee.