### PR TITLE
activation TCK 2.1.1

### DIFF
--- a/activation/2.1/_index.md
+++ b/activation/2.1/_index.md
@@ -31,6 +31,7 @@ appropriate bean to perform the operation(s).
   ([sig](https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.0.zip.sig),
   [sha](https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.0.zip.sha256),
   [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+  * Addresses Activation Challenge (Issue [#98](https://github.com/jakartaee/jaf-api/issues/98))  [Jakarta Activation 2.1.1 TCK](https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.1.zip)  ([sig](https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.1.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
     * [jakarta.activation:jakarta.activation-api:jar:2.1.0](https://search.maven.org/artifact/jakarta.activation/jakarta.activation-api/2.1.0/jar)
 


### PR DESCRIPTION
promote jakarta activation 2.1.1 tck addressing [linked tck challenge](https://github.com/jakartaee/jaf-api/issues/98), please.

Staged TCK binary: https://www.eclipse.org/downloads/download.php?file=/ee4j/jaf/jakartaee10/staged/eftl/jakarta-activation-tck-2.1.1.zip