### PR TITLE
mail TCK 2.1.1

### DIFF
--- a/mail/2.1/_index.md
+++ b/mail/2.1/_index.md
@@ -24,6 +24,7 @@ None
 * [Jakarta Mail 2.1 Specification Document](./jakarta-mail-spec-2.1.html) (HTML)
 * [Jakarta Mail 2.1 Javadoc](./apidocs)
 * [Jakarta Mail 2.1 TCK](https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.0.zip)  ([sig](https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.0.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+    * Addresses Mail Challenge (Issue [#625](https://github.com/jakartaee/mail-api/issues/625))  [Jakarta Mail 2.1.1 TCK](https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.1.zip)  ([sig](https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.1.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
     * [jakarta.mail:jakarta.mail-api:jar:2.1.0](https://search.maven.org/artifact/jakarta.mail/jakarta.mail-api/2.1.0/jar)
 


### PR DESCRIPTION
promote jakarta mail 2.1.1 tck addressing [linked tck challenge](https://github.com/jakartaee/mail-api/issues/625), please.

Staged TCK binary: https://www.eclipse.org/downloads/download.php?file=/ee4j/mail/jakartaee10/staged/eftl/jakarta-mail-tck-2.1.1.zip