### PR TITLE
Add TCK 4.0.2 as a third TCK, and update Mojarra to 4.0.2

### DIFF
--- a/faces/4.0/_index.md
+++ b/faces/4.0/_index.md
@@ -53,13 +53,14 @@ support for internationalization and accessibility.
 * [Jakarta Faces 4.0 Renderkitdoc](./renderkitdoc)
 * [Jakarta Faces 4.0 VDLDoc](./vdldoc)
 * [Jakarta Faces 4.0 TCK](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.0.zip)([sig](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.0.zip.sig),[sha](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.0.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
-   * First service release [Jakarta Faces 4.0 TCK](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip)([sig](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * First service release [Jakarta Faces 4.0.1 TCK](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip)([sig](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip.sig),[sha](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * Second service release [Jakarta Faces 4.0.2 TCK](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.2.zip)([sig](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.2.zip.sig),[sha](https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.2.zip.sha256),[pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.faces:jakarta.faces-api:jar:4.0.1](https://search.maven.org/artifact/jakarta.faces/jakarta.faces-api/4.0.1/jar)
 
 # Compatible Implementations
 
-* [Mojarra 4.0.0](https://github.com/eclipse-ee4j/mojarra/releases/download/4.0.0-RELEASE/jakarta.faces-4.0.0.jar)
+* [Mojarra 4.0.2](https://github.com/eclipse-ee4j/mojarra/releases/download/4.0.2-RELEASE/jakarta.faces-4.0.2.jar)
 
 # Ballots
 ## Release Review


### PR DESCRIPTION
Please run the TCK release script to make the release official and transfer 

from

https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-faces-tck-4.0.2.zip

to

https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.2.zip

cc @ivargrimstad @Emily-Jiang 