### PR TITLE
Add TCK 3.0.1 as a second TCK, and update Soteria to 3.0.2

### DIFF
--- a/security/3.0/_index.md
+++ b/security/3.0/_index.md
@@ -25,12 +25,13 @@ Jakarta Security defines a standard for creating secure Jakarta EE applications 
 * [Jakarta Security 3.0 Specification Document](./jakarta-security-spec-3.0.html) (HTML)
 * [Jakarta Security 3.0 Javadoc](./apidocs)
 * [Jakarta Security 3.0 TCK](https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.0.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+   * First service release [Jakarta Security 3.0.1 TCK](https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.1.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.security.enterprise:jakarta.security.enterprise-api:jar:3.0.0](https://search.maven.org/artifact/jakarta.security.enterprise/jakarta.security.enterprise-api/3.0.0/jar)
 
 # Compatible Implementations
 
-* [Eclipse Soteria 3.0.0-RC1](https://eclipse-ee4j.github.io/soteria)
+* [Eclipse Soteria 3.0.2](https://eclipse-ee4j.github.io/soteria)
 
 # Ballots
 


### PR DESCRIPTION
Please run the TCK release script to make the release official and transfer 

from

https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-security-tck-3.0.1.zip

to

https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.1.zip

cc @ivargrimstad @Emily-Jiang 