### PR TITLE
Promote CDI TCK 4.0.10

### DIFF
--- a/cdi/4.0/_index.md
+++ b/cdi/4.0/_index.md
@@ -28,9 +28,9 @@ Compatible (Reflection-Free)
 * [Jakarta Contexts Dependency Injection 4.0 Specification Document](./jakarta-cdi-spec-4.0.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 4.0 Specification Document](./jakarta-cdi-spec-4.0.html) (HTML)
 * [Jakarta Contexts Dependency Injection 4.0 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 4.0 TCK](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.9-dist.zip)
-([sig](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.9-dist.zip.sig),
-[sha](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.9-dist.zip.sha256),
+* [Jakarta Contexts Dependency Injection 4.0 TCK](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.10-dist.zip)
+([sig](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.10-dist.zip.sig),
+[sha](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.10-dist.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 
 * Maven coordinates


### PR DESCRIPTION
CDI TCK 4.0.10 was released on May 29 and is available in Central but I forgot to update it here.

CC @scottmarlow - follow up on your thread from the mailing list, sorry I left out this step :)