### PR TITLE
Update for changes in the CDI 4.1 restructuring review

### DIFF
--- a/cdi/4.1/_index.md
+++ b/cdi/4.1/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta Contexts and Dependency Injection 4.1 (Under development)"
-date: 2022-05-30
+date: 2023-11-06
 summary: "Release for Jakarta EE 11"
 ---
 
@@ -10,6 +10,9 @@ Jakarta Contexts Dependency Injection specifies a means for obtaining objects in
 <!-- List here -->
 Several minor issues in the Specification, APIs and TCK will be addresses as detailed in the [CDI 4.1 Milestone](https://github.com/jakartaee/cdi/milestone/1)
 The overview of currently suggested topics includes:
+* Breaking up spec/TCK to remove circular dependencies
+* Delegate integration requirements to the CDI EE specification
+* Method invokers
 * Executable methods
 * Getting interceptor bindings in standard way
 * @Priority on producers
@@ -32,7 +35,7 @@ and refactors features that are not client facing into the subinterface.
 
 ### Minimum Java SE Version
 <!-- Specify the minimum required Java SE version for this specification -->
-**Java SE 11 or higher**
+**Java SE 21 or higher**
 
 # Details
 
@@ -41,9 +44,9 @@ and refactors features that are not client facing into the subinterface.
 * [Jakarta Contexts Dependency Injection 4.1 Specification Document](./jakarta-cdi-spec-4.1.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 4.1 Specification Document](./jakarta-cdi-spec-4.1.html) (HTML)
 * [Jakarta Contexts Dependency Injection 4.1 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 4.1 TCK](https://download.eclipse.org/jakartaee/cdi/4.1/cdi-tck-4.1.0-dist.zip)
-([sig](https://download.eclipse.org/jakartaee/cdi/4.1/cdi-tck-4.1.9-dist.zip.sig),
-[sha](https://download.eclipse.org/jakartaee/cdi/4.1/cdi-tck-4.1.9-dist.zip.sha256),
+* [Jakarta Contexts Dependency Injection 4.1 TCK](https://download.eclipse.org/jakartaee/cdi/4.1/TBD.zip)
+([sig](https://download.eclipse.org/jakartaee/cdi/4.1/TBD.sig),
+[sha](https://download.eclipse.org/jakartaee/cdi/4.1/TBD.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 
 * Maven coordinates


### PR DESCRIPTION
## Specification PR template
When creating a specification project release review, create PRs with the content defined as follows.

Include the following in the PR:
- [x] A directory in the form wombat/x.y where x.y is the release major.minor version, and the directory contains the following.
- [ ] Specification PDF in the form of jakarta-wombat-spec-x.y.pdf
N/A
- [ ] Specification HTML in the form of jakarta-wombat-spec-x.y.html
N/A
- [x] A specification page named _index.md following the template at:
      https://github.com/jakartaee/specification-committee/blob/master/spec_page_template.md
- [ ] For a Progress Review, that sufficient progress has been made on a Compatible Implementation and TCK, to ensure that the spec is implementable and testable.
N/A
- [ ] For a [Release Review](https://www.eclipse.org/projects/handbook/#release-review), a summary that a Compatible Implementation is complete, passes the TCK, and that the TCK includes sufficient coverage of the specification. The TCK users guide MUST include the instructions to run the compatible implementations used to validate the release.
Instructions MAY be by reference.
   - [ ] Updated release record
   - [ ] Generated IP Log
   - [x] Email to PMC
   - [x] Start release review by emailing EMO 
- [ ] The URL of the OSSRH staging repository for the api, javadoc:
N/A
- [ ] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
N/A
- [ ] The URL of the compatibility certification request issue:
N/A
- [ ] Specification JavaDoc in the wombat/x.y/apidocs directory. 
If desired, an optional second PR can be created to contain just the JavaDoc in the `apidocs` directory.
N/A

Note: If any item does not apply, check it and mark N/A below it.

This is a restructuring review for the breakup of the CDI TCK and specification to extract the non-core profile integration requirements and TCK tests into a new CDI EE specification