### PR TITLE
Promote XML Binding 4.0.1 TCK for challenge issue 82

### DIFF
--- a/xml-binding/4.0/_index.md
+++ b/xml-binding/4.0/_index.md
@@ -35,6 +35,7 @@ between XML documents and Java objects.
 * [Jakarta XML Binding 4.0 Javadoc](./apidocs)
 * [Jakarta XML Binding 3.0 XML Schema](https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd)
 * [Jakarta XML Binding 4.0 TCK](https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+    * Addresses XML Binding Challenge (Issue [#82](https://github.com/jakartaee/jaxb-tck/issues/82))  [Jakarta XML Binding 4.0.1 TCK](https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.1.zip)  ([sig](https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.1.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
     * [jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.0](https://search.maven.org/artifact/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/jar)
 


### PR DESCRIPTION
Please promote the XML Binding 4.0.1 TCK for accepted challenge https://github.com/jakartaee/jaxb-tck/issues/82

Could one of the Specifications Committee members please run the https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release job to promote the https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-xml-binding-tck-4.0.1.zip TCK

I think the parameters to pass in would be ([as per previous job](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/211/parameters/)):

1. SPEC_NAME=xml-binding
2. SPEC_VERSION=4.0
3. FILE_URLS=https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-xml-binding-tck-4.0.1.zip
