### PR TITLE
Fix Searching in the EE10 Javadoc leads to a broken link

### DIFF
--- a/coreprofile/10/apidocs/search.js
+++ b/coreprofile/10/apidocs/search.js
@@ -50,7 +50,7 @@ function getURLPrefix(ui) {
             return ui.item.m + slash;
         } else if ((ui.item.category === catTypes && ui.item.p) || ui.item.category === catMembers) {
             $.each(packageSearchIndex, function(index, item) {
-                if (ui.item.p == item.l) {
+                if (ui.item.p == item.l && item.m) {
                     urlPrefix = item.m + slash;
                 }
             });

--- a/platform/10/apidocs/search.js
+++ b/platform/10/apidocs/search.js
@@ -50,7 +50,7 @@ function getURLPrefix(ui) {
             return ui.item.m + slash;
         } else if ((ui.item.category === catTypes && ui.item.p) || ui.item.category === catMembers) {
             $.each(packageSearchIndex, function(index, item) {
-                if (ui.item.p == item.l) {
+                if (ui.item.p == item.l && item.m) {
                     urlPrefix = item.m + slash;
                 }
             });

--- a/webprofile/10/apidocs/search.js
+++ b/webprofile/10/apidocs/search.js
@@ -50,7 +50,7 @@ function getURLPrefix(ui) {
             return ui.item.m + slash;
         } else if ((ui.item.category === catTypes && ui.item.p) || ui.item.category === catMembers) {
             $.each(packageSearchIndex, function(index, item) {
-                if (ui.item.p == item.l) {
+                if (ui.item.p == item.l && item.m) {
                     urlPrefix = item.m + slash;
                 }
             });


### PR DESCRIPTION
Platform and profile Javadocs for EE 10 don't use modules, but the generated Javadoc wants to add module into the URL, which results in "/undefined/" in the URL. 

This fix avoids adding "undefined" into the URL and fixes https://github.com/jakartaee/platform/issues/613.

---

A preview in Netlify here: https://deploy-preview-676--jakartaee-specifications.netlify.app/specifications/platform/10/apidocs/

---

Note: The trailing slash is important for URLs to JS resources to work. The trailing slash is not added by Netlify into the generated pages, so if you browse to the Javadocs from the root Netlify preview page, the Javadoc page will be broken. This doesn't happen in the jakarta.ee page, because probably the server contains a redirect from /apidocs to /apidocs/.

