### PR TITLE
Promote CDI TCK 4.0.13

### DIFF
--- a/cdi/4.0/_index.md
+++ b/cdi/4.0/_index.md
@@ -28,9 +28,9 @@ Compatible (Reflection-Free)
 * [Jakarta Contexts Dependency Injection 4.0 Specification Document](./jakarta-cdi-spec-4.0.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 4.0 Specification Document](./jakarta-cdi-spec-4.0.html) (HTML)
 * [Jakarta Contexts Dependency Injection 4.0 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 4.0 TCK](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.12-dist.zip)
-([sig](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.12-dist.zip.sig),
-[sha](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.12-dist.zip.sha256),
+* [Jakarta Contexts Dependency Injection 4.0 TCK](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.13-dist.zip)
+([sig](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.13-dist.zip.sig),
+[sha](https://download.eclipse.org/jakartaee/cdi/4.0/cdi-tck-4.0.13-dist.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 
 * Maven coordinates


### PR DESCRIPTION
Today I've issued a maintenance release for CDI TCK (4.0.13) that contains fixes for two challenges:

* https://github.com/jakartaee/cdi-tck/pull/503
* https://github.com/jakartaee/cdi-tck/pull/515