### PR TITLE
On branch edburns-msft-jea-276-progress-review: Commence progress review

### DIFF
--- a/coreprofile/11/_index.md
+++ b/coreprofile/11/_index.md
@@ -15,7 +15,7 @@ The Jakarta EE Core Profile defines a profile of the Jakarta EE platform specifi
 
 ### Minimum Java SE Version
 <!-- Specify the minimum required Java SE version for this specification -->
-**Java SE 21 or higher**
+**Java SE 17 or higher**
 
 # Details
 

--- a/platform/11/_index.md
+++ b/platform/11/_index.md
@@ -8,7 +8,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 ### New features, enhancements or additions
 <!-- List here -->
 * Support for Java Records 
-* Support for Virtual Threads
+* JDK Runtime aware support for Virtual Threads
 * Jakarta Data 1.0
 
 ### Removals, deprecations or backwards incompatible changes
@@ -19,7 +19,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 
 ### Minimum Java SE Version
 <!-- Specify the minimum required Java SE version for this specification -->
-**Java SE 21 or higher**
+**Java SE 17 or higher**
 
 # Details
 

--- a/webprofile/11/_index.md
+++ b/webprofile/11/_index.md
@@ -8,7 +8,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 ### New features, enhancements or additions
 <!-- List here -->
 * Support for Java Records 
-* Support for Virtual Threads
+* JDK Runtime aware support for Virtual Threads
 * Jakarta Data 1.0
 ### Removals, deprecations or backwards incompatible changes
 <!-- List here -->
@@ -17,7 +17,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 
 ### Minimum Java SE Version
 <!-- Specify the minimum required Java SE version for this specification -->
-**Java SE 21 or higher**
+**Java SE 17 or higher**
 
 # Details
 


### PR DESCRIPTION
modified:   coreprofile/11/_index.md
modified:   platform/11/_index.md
modified:   webprofile/11/_index.md

This change allows for several things while not restricting anything.

- It *allows* compatible runtimes to certify on Java SE 17 **OR** 21, while simultaneously *allowing* Concurrency to provide Java SE version runtime aware support for Virtual Threads.
- It *allows* users who are not at liberty to run Java SE 21 to adopt Jakarta EE 11.
- It *allows* us to keep our delivery schedule of June/July 2024 to complete Jakarta EE 11.

