### PR TITLE
ca#109: spec page should list @Nonnull instead of @NotNull

### DIFF
--- a/annotations/2.1/_index.md
+++ b/annotations/2.1/_index.md
@@ -8,7 +8,7 @@ Jakarta Annotations defines a collection of annotations representing common sema
 ### New features, enhancements or additions
 <!-- List here -->
 * Allow @Priority to be used everywhere [Issue #86](https://github.com/eclipse-ee4j/common-annotations-api/issues/86)
-* Add @Nullable and @NotNull annotations [Issue #89](https://github.com/eclipse-ee4j/common-annotations-api/issues/89)
+* Add @Nullable and @Nonnull annotations [Issue #89](https://github.com/eclipse-ee4j/common-annotations-api/issues/89)
 
 ### Removals, deprecations or backwards incompatible changes
 <!-- List here -->


### PR DESCRIPTION
Annotation spec in v 2.1 in the end added _@Nonnull_ instead of _@NotNull_ as is said on the spec page. Would be good to fix the name here to avoid confusion. See https://github.com/jakartaee/common-annotations-api/issues/109