### PR TITLE
Fix text of Javadoc anchor that is for Servlet 6.1

### DIFF
--- a/servlet/6.1/_index.md
+++ b/servlet/6.1/_index.md
@@ -28,7 +28,7 @@ The release removes references to the SecurityManager and provides various small
   * [Jakarta EE Platform 11 Release Plan](https://jakartaee.github.io/platform/jakartaee11/JakartaEE11ReleasePlan)
 * [Jakarta Servlet 6.1 Specification Document](./jakarta-servlet-spec-6.1.pdf) (PDF)
 * [Jakarta Servlet 6.1 Specification Document](./jakarta-servlet-spec-6.1.html) (HTML)
-* [Jakarta Servlet 6.0 Javadoc](./apidocs)
+* [Jakarta Servlet 6.1 Javadoc](./apidocs)
 * [Jakarta Servlet 6.1.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip), ([sig](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * XML Schema
   * web-app_6_1.xsd


### PR DESCRIPTION
Currently at https://jakarta.ee/specifications/servlet/6.1/:

![image](https://github.com/user-attachments/assets/7bbc77e3-5041-4d45-8ca7-0a995a5abcf1)

