### PR TITLE
Add REST TCK 4.0.1 Service release info

### DIFF
--- a/restful-ws/4.0/_index.md
+++ b/restful-ws/4.0/_index.md
@@ -36,6 +36,8 @@ earlier releases.
 * [Jakarta RESTful Web Services 4.0 Specification Document](./jakarta-restful-ws-spec-4.0.html) (HTML)
 * [Jakarta RESTful Web Services 4.0 Javadoc](./apidocs)
 * [Jakarta RESTful Web Services 4.0.0 TCK](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.0.zip)  ([sig](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.0.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* First service release [Jakarta RESTful Web Services 4.0.1 TCK]
+(https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
     * [jakarta.jaxrs:jakarta.jaxrs-api:jar:4.0.0](https://search.maven.org/artifact/jakarta.ws.rs/jakarta.ws.rs-api/4.0.0/jar)
 


### PR DESCRIPTION
Adding release 4.0.1 of the Jakarta RESTful Web Services TCK

Should only be merged after copying from:

[https://www.eclipse.org/downloads/download.php?file=/ee4j/restful-ws/tck/eftl/jakarta-restful-ws-tck-4.0.1.zip](https://www.eclipse.org/downloads/download.php?file=/ee4j/restful-ws/tck/eftl/jakarta-restful-ws-tck-4.0.1.zip)
to
https://download.eclipse.org/jakartaee/restful-ws/4.0.1/jakarta-restful-ws-tck-4.0.1.zip