### PR TITLE
Include maven coordinates for Faces 4.1 API

### DIFF
--- a/faces/4.1/_index.md
+++ b/faces/4.1/_index.md
@@ -41,6 +41,8 @@ The removes references to the SecurityManager, further aligns with CDI where pos
 * [Jakarta Faces 4.1 Renderkitdoc](./renderkitdoc)
 * [Jakarta Faces 4.1 VDLDoc](./vdldoc)
 * [Jakarta Faces 4.1 TCK](https://download.eclipse.org/jakartaee/faces/4.1/jakarta-faces-tck-4.1.0.zip) ([sig](https://download.eclipse.org/jakartaee/faces/4.1/jakarta-faces-tck-4.1.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/faces/4.1/jakarta-faces-tck-4.1.0.zip.sha256), [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* Maven coordinates
+  * [jakarta.faces:jakarta.faces-api:jar:4.1.0](https://central.sonatype.com/artifact/jakarta.faces/jakarta.faces-api/4.1.0/jar)
 
 # Compatible Implementations
 


### PR DESCRIPTION
[Faces 4.0](https://jakarta.ee/specifications/faces/4.0/) has it:
![image](https://github.com/user-attachments/assets/6c680570-b896-4b30-9667-ca7579f318e6)

[Faces 4.1](https://jakarta.ee/specifications/faces/4.1/) does not have it:
![image](https://github.com/user-attachments/assets/e9494095-8344-46a8-a095-37b6698c7f05)

4.1.0 was referenced in:
- https://github.com/jakartaee/specifications/pull/738
![image](https://github.com/user-attachments/assets/4d263372-d1fe-4710-92ad-0223901a8049)
