### PR TITLE
Fix text for maven coordinates in restful-ws 3.0/3.1/4.0

### DIFF
--- a/restful-ws/3.0/_index.md
+++ b/restful-ws/3.0/_index.md
@@ -15,7 +15,7 @@ following the Representational State Transfer (REST) architectural pattern.
    * Addresses RESTFul Web Services Challenge ([Issue #937](https://github.com/eclipse-ee4j/jaxrs-api/issues/937)) [Jakarta RESTful Web Services 3.0.1 TCK](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.1.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
    * Adds JDK 11 support [Jakarta RESTful Web Services 3.0.2 TCK](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.2.zip)  ([sig](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.2.zip.sig),  [sha](https://download.eclipse.org/jakartaee/restful-ws/3.0/jakarta-restful-ws-tck-3.0.2.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
-  * [jakarta.jaxrs:jakarta.jaxrs-api:jar:3.0.0](https://central.sonatype.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/jar)
+  * [jakarta.ws.rs:jakarta.ws.rs-api:jar:3.0.0](https://central.sonatype.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/jar)
 
 
 # Compatible Implementations

--- a/restful-ws/3.1/_index.md
+++ b/restful-ws/3.1/_index.md
@@ -38,7 +38,7 @@ backward compatibility with earlier releases.
    * Fourth service release [Jakarta RESTful Web Services 3.1.4 TCK](https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.4.zip)  ([sig](https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.4.zip.sig),  [sha](https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.4.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
    * Fifth service release [Jakarta RESTful Web Services 3.1.5 TCK](https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.5.zip)  ([sig](https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.5.zip.sig),  [sha](https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.5.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
-    * [jakarta.jaxrs:jakarta.jaxrs-api:jar:3.1.0](https://central.sonatype.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0/jar)
+    * [jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0](https://central.sonatype.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0/jar)
 
 # Compatible Implementations
 

--- a/restful-ws/4.0/_index.md
+++ b/restful-ws/4.0/_index.md
@@ -39,7 +39,7 @@ earlier releases.
 * First service release [Jakarta RESTful Web Services 4.0.1 TCK]
 (https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.1.zip) ([sig](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/restful-ws/4.0/jakarta-restful-ws-tck-4.0.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
-    * [jakarta.jaxrs:jakarta.jaxrs-api:jar:4.0.0](https://central.sonatype.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/4.0.0/jar)
+    * [jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0](https://central.sonatype.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/4.0.0/jar)
 
 # Compatible Implementations
 * [RESTEasy 7.0.0.Alpha1](https://github.com/resteasy/resteasy/releases/tag/7.0.0.Alpha1)


### PR DESCRIPTION
The links seems fine, but the texts do not correspond to them.