### PR TITLE
Fix project_id for Messaging

### DIFF
--- a/messaging/_index.md
+++ b/messaging/_index.md
@@ -3,5 +3,5 @@ title: "Jakarta Messaging"
 summary: "Jakarta Messaging describes a means for Java applications to create, send, and receive messages via loosely coupled, reliable asynchronous communication services."
 #<!--.................0123456789.123456789.123456789.123456789.123456789.123456789-->
 summary_sixty_char: "Messaging via loosely coupled, reliable asynch services"
-project_id: "ee4j.jms"
+project_id: "ee4j.messaging"
 ---


### PR DESCRIPTION
Currently - live on page - _could not load project_ badge:
![ee4j spec jms](https://github.com/user-attachments/assets/2444fd28-58e2-413e-bd93-17982856cbbb)
![ee4j jms](https://github.com/user-attachments/assets/5b3b5ca8-4752-4c23-a5b9-283557412cb1)
