### PR TITLE
Add 3.1.1. service release of authentication TCK to spec page

### DIFF
--- a/authentication/3.1/_index.md
+++ b/authentication/3.1/_index.md
@@ -25,15 +25,15 @@ The release aims to evolve the API in a smaller way to support the overall goals
 * [Jakarta Authentication 3.1 Specification Document](./jakarta-authentication-spec-3.1.pdf) (PDF)
 * [Jakarta Authentication 3.1 Specification Document](./jakarta-authentication-spec-3.1.html) (HTML)
 * [Jakarta Authentication 3.1 Javadoc](./apidocs)
-* [Jakarta Authentication 3.1 TCK](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.0.zip)  ([sig](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Authentication 3.1 TCK](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip)  ([sig](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.authentication:jakarta.authentication-api:jar:3.1.0](https://central.sonatype.com/artifact/jakarta.authentication/jakarta.authentication-api/3.1.0/jar)
 
 # Compatible Implementations
 
  * [Epicyro 3.1.0](https://github.com/eclipse-ee4j/epicyro/releases/download/3.1.0-RELEASE/epicyro-3.1.0.jar)
- * [Eclipse Glassfish 8.0.0-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-M6/glassfish-8.0.0-M6.zip) (JDK 21)
- * [Eclipse Glassfish 8.0.0-JDK-17-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-JDK17-M6/) (JDK 17)
+ * [Eclipse Glassfish 8.0.0-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-M6/glassfish-8.0.0-M7.zip) (JDK 21)
+ * [Eclipse Glassfish 8.0.0-JDK-17-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-JDK17-M7/) (JDK 17)
 
 # Ballots
 

--- a/authentication/3.1/_index.md
+++ b/authentication/3.1/_index.md
@@ -33,8 +33,8 @@ The release aims to evolve the API in a smaller way to support the overall goals
 # Compatible Implementations
 
  * [Epicyro 3.1.0](https://github.com/eclipse-ee4j/epicyro/releases/download/3.1.0-RELEASE/epicyro-3.1.0.jar)
- * [Eclipse Glassfish 8.0.0-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-M6/glassfish-8.0.0-M7.zip) (JDK 21)
- * [Eclipse Glassfish 8.0.0-JDK-17-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-JDK17-M7/) (JDK 17)
+ * [Eclipse Glassfish 8.0.0-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-M6/glassfish-8.0.0-M6.zip) (JDK 21)
+ * [Eclipse Glassfish 8.0.0-JDK-17-M6](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0-JDK17-M6/) (JDK 17)
 
 # Ballots
 

--- a/authentication/3.1/_index.md
+++ b/authentication/3.1/_index.md
@@ -25,7 +25,8 @@ The release aims to evolve the API in a smaller way to support the overall goals
 * [Jakarta Authentication 3.1 Specification Document](./jakarta-authentication-spec-3.1.pdf) (PDF)
 * [Jakarta Authentication 3.1 Specification Document](./jakarta-authentication-spec-3.1.html) (HTML)
 * [Jakarta Authentication 3.1 Javadoc](./apidocs)
-* [Jakarta Authentication 3.1 TCK](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip)  ([sig](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+* [Jakarta Authentication 3.1 TCK](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.0.zip)  ([sig](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.0.zip.sig),  [sha](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.0.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
+  * First service release [Jakarta Authentication 3.1.1 TCK](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip)  ([sig](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip.sig),  [sha](https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip.sha256),  [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates
   * [jakarta.authentication:jakarta.authentication-api:jar:3.1.0](https://central.sonatype.com/artifact/jakarta.authentication/jakarta.authentication-api/3.1.0/jar)
 


### PR DESCRIPTION
https://download.eclipse.org/security/jakartaee11/staged/eftl/jakarta-authentication-tck-3.1.1.zip

needs to be promoted to

https://download.eclipse.org/jakartaee/authentication/3.1/jakarta-authentication-tck-3.1.1.zip

cc @ivargrimstad @jhanders34