### PR TITLE
Promote Servlet 6.1.1 TCK

### DIFF
--- a/servlet/6.1/_index.md
+++ b/servlet/6.1/_index.md
@@ -29,7 +29,8 @@ The release removes references to the SecurityManager and provides various small
 * [Jakarta Servlet 6.1 Specification Document](./jakarta-servlet-spec-6.1.pdf) (PDF)
 * [Jakarta Servlet 6.1 Specification Document](./jakarta-servlet-spec-6.1.html) (HTML)
 * [Jakarta Servlet 6.1 Javadoc](./apidocs)
-* [Jakarta Servlet 6.1.1 TCK](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip), ([sig](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta Servlet 6.1.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip), ([sig](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+  * Excludes response flushBufferTest (Issue [#525](https://github.com/jakartaee/servlet/issues/525)) [Jakarta Servlet 6.1.1 TCK](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip), ([sig](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * XML Schema
   * web-app_6_1.xsd
   * web-common_6_1.xsd

--- a/servlet/6.1/_index.md
+++ b/servlet/6.1/_index.md
@@ -29,7 +29,7 @@ The release removes references to the SecurityManager and provides various small
 * [Jakarta Servlet 6.1 Specification Document](./jakarta-servlet-spec-6.1.pdf) (PDF)
 * [Jakarta Servlet 6.1 Specification Document](./jakarta-servlet-spec-6.1.html) (HTML)
 * [Jakarta Servlet 6.1 Javadoc](./apidocs)
-* [Jakarta Servlet 6.1.0 TCK](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip), ([sig](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta Servlet 6.1.1 TCK](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip), ([sig](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip.sig), [sha](https://download.eclipse.org/jakartaee/servlet/6.1/jakarta-servlet-tck-6.1.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * XML Schema
   * web-app_6_1.xsd
   * web-common_6_1.xsd


### PR DESCRIPTION
## Specification PR template
When creating a specification project release review, create PRs with the content defined as follows.

Include the following in the PR:
- [X] A directory in the form wombat/x.y where x.y is the release major.minor version, and the directory contains the following.
servlet/6.1/_index.md

- [X] Specification PDF in the form of jakarta-wombat-spec-x.y.pdf
jakarta-servlet-spec-6.1.pdf
- [X] Specification HTML in the form of jakarta-wombat-spec-x.y.html
jakarta-servlet-spec-6.1.html
- [X] A specification page named _index.md following the template at:
      https://github.com/jakartaee/specifications/blob/master/servlet/6.1/_index.md
- [X] For a Progress Review, that sufficient progress has been made on a Compatible Implementation and TCK, to ensure that the spec is implementable and testable.
Tested the staged Servlet 6.1.1 TCK version.
- [ ] For a [Release Review](https://www.eclipse.org/projects/handbook/#release-review), a summary that a Compatible Implementation is complete, passes the TCK, and that the TCK includes sufficient coverage of the specification. The TCK users guide MUST include the instructions to run the compatible implementations used to validate the release.
Instructions MAY be by reference.
   - [ ] Updated release record
   - [ ] Generated IP Log
   - [ ] Email to PMC
   - [ ] Start release review by emailing EMO 
- [X] The URL of the OSSRH staging repository for the api, javadoc:
      N/A
- [X] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
      https://www.eclipse.org/downloads/download.php?file=/ee4j/servlet/jakartaee11/staged/eftl/jakarta-servlet-tck-6.1.1.zip
- [X] The URL of the compatibility certification request issue:
      N/A
- [X] Specification JavaDoc in the wombat/x.y/apidocs directory. 
     N/A
If desired, an optional second PR can be created to contain just the JavaDoc in the `apidocs` directory.

Note: If any item does not apply, check it and mark N/A below it.
