### PR TITLE
Update Core Profile 10 TCK service release version to 10.0.4

### DIFF
--- a/coreprofile/10/_index.md
+++ b/coreprofile/10/_index.md
@@ -32,6 +32,8 @@ The goals for this release were:
   ([sig](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.1.zip.sig),
   [sha](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.1.zip.sha256),
   [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+   * Publish TCK Artifacts to Maven Central (Issue [#1960](https://github.com/jakartaee/platform-tck/issues/1960)
+     * [Jakarta Core Profile 10.0.4 TCK](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.4.zip)  ([sig](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.4.zip.sig),  [sha](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.4.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
    * Address Core Profile TCK Challenge (Issue [#1196](https://github.com/jakartaee/platform-tck/issues/1196)) [Jakarta Core Profile 10.0.3 TCK](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.3.zip)  ([sig](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.3.zip.sig),  [sha](https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.3.zip.sha256),  [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Maven coordinates
     * [jakarta.platform:jakarta.jakartaee-core-api:jar:10.0.0](https://central.sonatype.com/artifact/jakarta.platform/jakarta.jakartaee-core-api/10.0.0/jar)


### PR DESCRIPTION
https://github.com/jakartaee/platform-tck/issues/1960

The staged TCK binary is at: 
https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-core-profile-tck-10.0.4.zip

## Specification PR template
When creating a specification project release review, create PRs with the content defined as follows.


