### PR TITLE
Fix project_id of Portlet Bridge

### DIFF
--- a/portlet-bridge/_index.md
+++ b/portlet-bridge/_index.md
@@ -3,7 +3,7 @@ title: "Jakarta Portlet Bridge"
 summary: "Defines how Jakarta Faces applications can run within portlet containers by bridging the JSF and portlet lifecycles."
 #<!--.................0123456789.123456789.123456789.123456789.123456789.123456789-->
 summary_sixty_char: "Bridge API for running Faces webapps in portlet containers"
-project_id: "ee4j.faces-bridge"
+project_id: "ee4j.portlet-bridge"
 ---
 
 Jakarta Portlet Bridge defines the behavior and APIs necessary for Jakarta Faces applications to operate within a portlet environment. It provides a bridge that aligns the Jakarta Faces lifecycle with the Jakarta Portlet lifecycle. This enables developers to use features such as declarative Facelet views, navigation-rules, and component suites while maintaining compatibility with the multi-phase request and response model defined by portlet containers.


### PR DESCRIPTION
Currently:
![image](https://github.com/user-attachments/assets/b1582c6b-e295-4184-9b3c-f15ff5cef00d)

With this PR:
![image](https://github.com/user-attachments/assets/48b7c793-026a-4438-bc24-07b75d13c037)
