### PR TITLE
Fix up some page references

### DIFF
--- a/bean-validation/3.1/_index.md
+++ b/bean-validation/3.1/_index.md
@@ -78,8 +78,3 @@ The Specification Committee Ballot concluded successfully on 2023-08-01 with the
 
 The ballot was run on the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg03048.html)
 
-<!--
-## Release Review
-
-The Specification Committee Ballot concluded successfully on TBD with the following results.
--->

--- a/cdi/4.1/_index.md
+++ b/cdi/4.1/_index.md
@@ -43,7 +43,7 @@ and refactors features that are not client facing into the subinterface.
 * [Jakarta Contexts Dependency Injection 4.1 Specification Document](./jakarta-cdi-spec-4.1.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 4.1 Specification Document](./jakarta-cdi-spec-4.1.html) (HTML)
 * [Jakarta Contexts Dependency Injection 4.1 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 4.1.0 TCK](https://www.eclipse.org/downloads/download.php?file=/ee4j/cdi/4.1/cdi-tck-4.1.0-dist.zip)
+* [Jakarta Contexts Dependency Injection 4.1.0 TCK](https://download.eclipse.org/ee4j/cdi/4.1/cdi-tck-4.1.0-dist.zip)
 ([sig](https://download.eclipse.org/jakartaee/cdi/4.1/TBD.zip.sig),
 [sha](https://download.eclipse.org/jakartaee/cdi/4.1/TBD.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))

--- a/cdi/5.0/_index.md
+++ b/cdi/5.0/_index.md
@@ -36,7 +36,7 @@ Currently suggested topics includes:
 * [Jakarta Contexts Dependency Injection 5.0 Specification Document](./jakarta-cdi-spec-5.0.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 5.0 Specification Document](./jakarta-cdi-spec-5.0.html) (HTML)
 * [Jakarta Contexts Dependency Injection 5.0 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 5.0.0 TCK](https://www.eclipse.org/downloads/download.php?file=/ee4j/cdi/5.0/cdi-tck-5.0.0-dist.zip)
+* [Jakarta Contexts Dependency Injection 5.0.0 TCK](https://download.eclipse.org/ee4j/cdi/5.0/cdi-tck-5.0.0-dist.zip)
 ([sig](https://download.eclipse.org/jakartaee/cdi/5.0/TBD.zip.sig),
 [sha](https://download.eclipse.org/jakartaee/cdi/5.0/TBD.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))

--- a/concurrency/1.1/_index.md
+++ b/concurrency/1.1/_index.md
@@ -36,4 +36,4 @@ The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org
 
 # Compatible Implementations
 
-* [Eclipse GlassFish 5.1](https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip)
+* [Eclipse GlassFish 5.1](https://download.eclipse.org/glassfish/glassfish-5.1.0.zip)

--- a/connectors/1.7/_index.md
+++ b/connectors/1.7/_index.md
@@ -37,5 +37,5 @@ The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org
 
 # Compatible Implementations
 
-* [Eclipse GlassFish 5.1](https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip)
+* [Eclipse GlassFish 5.1](https://download.eclipse.org/glassfish/glassfish-5.1.0.zip)
 

--- a/connectors/2.0/_index.md
+++ b/connectors/2.0/_index.md
@@ -18,7 +18,7 @@ The Jakarta Connectors specification defines a standard architecture for Jakarta
 
 # Compatible Implementations
 
-* [Eclipse GlassFish 6.0.0-M1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-M1.zip)
+* [Eclipse GlassFish 6.0.0-M1](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-M1.zip)
 
 # Ballots
 

--- a/data/1.0/_index.md
+++ b/data/1.0/_index.md
@@ -122,6 +122,3 @@ The Specification Committee Ballot concluded successfully on 2023-04-03 with the
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02857.html)
 
-## Release Review
-
-TBD

--- a/faces/4.1/_index.md
+++ b/faces/4.1/_index.md
@@ -99,6 +99,3 @@ The Specification Committee Ballot completed on 11th July 2023.
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02949.html)
 
-## Release Review
-
-TBD

--- a/interceptors/2.2/_index.md
+++ b/interceptors/2.2/_index.md
@@ -32,7 +32,7 @@ The binary target level is 11.
 * [Jakarta Interceptors 2.2 Specification Document](./jakarta-interceptors-spec-2.2.pdf) (PDF)
 * [Jakarta Interceptors 2.2 Specification Document](./jakarta-interceptors-spec-2.2.html) (HTML)
 * [Jakarta Interceptors 2.2 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 4.1.0 TCK](https://www.eclipse.org/downloads/download.php?file=/ee4j/cdi/4.1/cdi-tck-4.1.0-dist.zip),
+* [Jakarta Contexts Dependency Injection 4.1.0 TCK](https://download.eclipse.org/ee4j/cdi/4.1/cdi-tck-4.1.0-dist.zip),
    [sha](7671d6895eb57b74b52e46b63adfeb57adf965dd91efc673db21a781fedc452f),
    [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
 * Maven coordinates

--- a/pages/4.1/_index.md
+++ b/pages/4.1/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta Pages 4.1 (under development)"
-date: 2026-05-26
+date: 2025-05-26
 summary: "Release for Jakarta EE 12"
 ---
 Jakarta Pages defines a template engine for web applications that supports mixing of textual content

--- a/platform/9/_index.md
+++ b/platform/9/_index.md
@@ -17,7 +17,7 @@ The Jakarta EE Platform defines a standard platform for hosting Jakarta EE appli
 * Maven coordinates
   * [jakarta.platform:jakarta.jakartaee-api:jar:9.0.0](https://central.sonatype.com/artifact/jakarta.platform/jakarta.jakartaee-api/9.0.0/jar)
 * Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
-  * [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
+  * [Eclipse Glassfish 6.0.0 RC2](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
   
 # Jakarta EE 9 Schedule
 * [Jakarta EE 9 Schedule](https://jakartaee.github.io/platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)

--- a/platform/9/_index.zh.md
+++ b/platform/9/_index.zh.md
@@ -18,7 +18,7 @@ Jakarta EE Platform 定义了承载 Jakarta EE 应用的标准平台.
 * [Jakarta EE 9 日程](https://jakartaee.github.io/platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)
 
 # 兼容实现
-* [Eclipse Glassfish 6.0.0-M1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-M1.zip)
+* [Eclipse Glassfish 6.0.0-M1](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-M1.zip)
 
 # 投票结果
 

--- a/tags/3.1/_index.md
+++ b/tags/3.1/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta Standard Tag Library 3.1 (under development)"
-date: 2026-05-26
+date: 2025-05-26
 summary: "Release for Jakarta EE 12"
 ---
 

--- a/webprofile/9/_index.md
+++ b/webprofile/9/_index.md
@@ -16,7 +16,7 @@ The Jakarta EE Web Profile defines a profile of the Jakarta EE Platform specific
 * Maven coordinates
   * [jakarta.platform:jakarta.webprofile-api:jar:9.0.0](https://central.sonatype.com/artifact/jakarta.platform/jakarta.jakartaee-web-api/9.0.0/jar)
 * Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
-  * [Eclipse Glassfish 6.0.0 RC2](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
+  * [Eclipse Glassfish 6.0.0 RC2](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-RC2.zip)
     
 # Jakarta EE 9 Schedule
 * [Jakarta EE 9 Schedule](https://jakartaee.github.io/platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule)

--- a/websocket/2.2/_index.md
+++ b/websocket/2.2/_index.md
@@ -95,5 +95,3 @@ The Specification Committee Ballot completed on 11th July 2023.
 
 The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg02948.html)
 
-## Release Review
-TBD

--- a/websocket/2.3/_index.md
+++ b/websocket/2.3/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta WebSocket 2.3 (under development)"
-date: 2026-05-26
+date: 2025-05-26
 summary: "Release for Jakarta EE 12"
 ---
 Jakarta WebSocket defines a API for Server and Client Endpoints for the WebSocket protocol (RFC6455).


### PR DESCRIPTION
- Update date for pages, tags and websocket vNext release to not be in the future so that it displays now and not a year from now
- Remove references to download.php since it will be removed at the end of the year.  Switch to the non php url.
- Clean up some additional Release Review TBD entries in a few pages