### PR TITLE
fix: malformed url breaks jakarta.ee build

### DIFF
--- a/cdi/4.1/_index.md
+++ b/cdi/4.1/_index.md
@@ -109,7 +109,7 @@ Non-binding votes
 |                                                | **Total**           |  **1**  |
 
 
-The ballot was run in the [jakarta.ee-spec mailing list]([https://www.eclipse.org/lists/jakarta.ee-spec/msg03150.html)
+The ballot was run in the [jakarta.ee-spec mailing list](https://www.eclipse.org/lists/jakarta.ee-spec/msg03150.html)
 
 ## Plan Review
 


### PR DESCRIPTION
This is just a content fix.
