### PR TITLE
Require Change Logs for Service Releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/service_release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/service_release_pr_template.md
@@ -11,4 +11,8 @@ Include the following in the PR:
 - [ ] Specification JavaDoc in the wombat/x.y/apidocs directory. 
 If desired, an optional second PR can be created to contain just the JavaDoc in the `apidocs` directory.
 
+- [ ] A change log page wombat/x.y/changelog.md following [template](https://github.com/jakartaee/specification-committee/blob/master/changelog_page_template.md)
+
+- [ ] Add an extra bullet point to the wombat/x.y/_index.md file under `Details` providing a link to the change log file (if not already present): `[Change Log](./changelog)`
+
 Note: If any item does not apply, check it and mark N/A below it.


### PR DESCRIPTION
Follow-up to Spec Committee Issue 83: https://github.com/jakartaee/specification-committee/issues/83

It was raised that there should be a way to see what the difference between the various TCK releases are.
The changelog file mechanism already exists, so this is a draft example of how we may update the format of this file to separate out TCK changes from API changes.

Counterpart to https://github.com/jakartaee/specification-committee/pull/88