### PR TITLE
Fix CDI 5.0 Beta1 TCK download links

### DIFF
--- a/cdi/5.0/_index.md
+++ b/cdi/5.0/_index.md
@@ -46,9 +46,9 @@ A complete list of issues and pull requests for this version can be viewed using
 * [Jakarta Contexts Dependency Injection 5.0 Specification Document](./jakarta-cdi-spec-5.0.pdf) (PDF)
 * [Jakarta Contexts Dependency Injection 5.0 Specification Document](./jakarta-cdi-spec-5.0.html) (HTML)
 * [Jakarta Contexts Dependency Injection 5.0 Javadoc](./apidocs)
-* [Jakarta Contexts Dependency Injection 5.0.0 TCK](https://download.eclipse.org/ee4j/cdi/5.0/cdi-tck-5.0.0-dist.zip)
-([sig](https://download.eclipse.org/jakartaee/cdi/5.0/TBD.zip.sig),
-[sha](https://download.eclipse.org/jakartaee/cdi/5.0/TBD.zip.sha256),
+* [Jakarta Contexts Dependency Injection 5.0.0.Beta1 TCK](https://download.eclipse.org/jakartaee/cdi/5.0/cdi-tck-5.0.0.Beta1-dist.zip)
+([sig](https://download.eclipse.org/jakartaee/cdi/5.0/cdi-tck-5.0.0.Beta1-dist.zip.sig),
+[sha](https://download.eclipse.org/jakartaee/cdi/5.0/cdi-tck-5.0.0.Beta1-dist.zip.sha256),
 [pub](https://raw.githubusercontent.com/jakartaee/specification-committee/master/jakartaee-spec-committee.pub))
   * For all TCK releases, see [download directory](https://download.eclipse.org/jakartaee/cdi/5.0)
 * Maven coordinates


### PR DESCRIPTION
A tiny followup to https://github.com/jakartaee/specifications/pull/904

I realized I can fix up the TCK links, so might as well :)