### PR TITLE
update: Jakarta JSON Binding 3.0.2 service release

### DIFF
--- a/jsonb/3.0/_index.md
+++ b/jsonb/3.0/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta JSON Binding 3.0"
-date: 2021-11-11
+date: 2026-05-29
 summary: "Release for Jakarta EE 10"
 ---
 Jakarta JSON Binding defines a binding framework for converting Java(R) objects to and from JSON documents.
@@ -28,7 +28,7 @@ Jakarta JSON Binding defines a binding framework for converting Java(R) objects 
 * [Jakarta JSON Binding 3.0 Specification Document](./jakarta-jsonb-spec-3.0.html) (HTML)
 * [Jakarta JSON Binding 3.0 Javadoc](./apidocs)
 * [Jakarta JSON Binding 3.0.0 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
-* Jakarta JSON Binding 3.0.0 TCK -- Intentionally missing no updates were made to the TCK for service release 3.0.1
+* Jakarta JSON Binding 3.0.1 TCK -- Intentionally missing no updates were made to the TCK for service release 3.0.1
 * [Jakarta JSON Binding 3.0.2 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0.2/jakarta-jsonb-tck-3.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0.2/jakarta-jsonb-tck-3.0.2.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0.2/jakarta-jsonb-tck-3.0.2.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
   * For all TCK releases, see [download directory](https://download.eclipse.org/jakartaee/jsonb/3.0/)
 * Maven coordinates

--- a/jsonb/3.0/_index.md
+++ b/jsonb/3.0/_index.md
@@ -27,10 +27,14 @@ Jakarta JSON Binding defines a binding framework for converting Java(R) objects 
 * [Jakarta JSON Binding 3.0 Specification Document](./jakarta-jsonb-spec-3.0.pdf) (PDF)
 * [Jakarta JSON Binding 3.0 Specification Document](./jakarta-jsonb-spec-3.0.html) (HTML)
 * [Jakarta JSON Binding 3.0 Javadoc](./apidocs)
-* [Jakarta JSON Binding 3.0 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta JSON Binding 3.0.0 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* Jakarta JSON Binding 3.0.0 TCK -- Intentionally missing no updates were made to the TCK for service release 3.0.1
+* [Jakarta JSON Binding 3.0.2 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0.2/jakarta-jsonb-tck-3.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0.2/jakarta-jsonb-tck-3.0.2.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0.2/jakarta-jsonb-tck-3.0.2.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
   * For all TCK releases, see [download directory](https://download.eclipse.org/jakartaee/jsonb/3.0/)
 * Maven coordinates
+  * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.0](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.0/jar)
   * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.1](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.1/jar)
+  * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.2](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.2/jar)
 * [Change Log](./changelog)
 
 # Compatible Implementations

--- a/jsonb/3.0/changelog.md
+++ b/jsonb/3.0/changelog.md
@@ -4,6 +4,11 @@ date: 2023-04-29
 summary: "Release for Jakarta EE 10"
 ---
 
+### CHANGES IN THE 3.0.2 RELEASE
+
+* Update TCK to allow implementations to certify on Java 25
+* Update API bundle to manifest to include Bundle-SymbolicName
+
 ### CHANGES IN THE 3.0.1 RELEASE
 
 * updates dependencies for usage in Jakarta EE 11

--- a/jsonb/3.0/changelog.md
+++ b/jsonb/3.0/changelog.md
@@ -1,13 +1,13 @@
 ---
 title: "Change Log"
-date: 2023-04-29
+date: 2026-05-29
 summary: "Release for Jakarta EE 10"
 ---
 
 ### CHANGES IN THE 3.0.2 RELEASE
 
-* Update TCK to allow implementations to certify on Java 25
-* Update API bundle to manifest to include Bundle-SymbolicName
+* updates TCK to allow implementations to certify on Java 25
+* updates API bundle manifest to include Bundle-SymbolicName
 
 ### CHANGES IN THE 3.0.1 RELEASE
 


### PR DESCRIPTION
## Specification PR template
When creating a specification project release review, create PRs with the content defined as follows.

Include the following in the PR:
- [x] A directory in the form wombat/x.y where x.y is the release major.minor version, and the directory contains the following.
- [x] Specification PDF in the form of jakarta-wombat-spec-x.y.pdf
- [x] Specification HTML in the form of jakarta-wombat-spec-x.y.html
- [x] A specification page named _index.md following the template at:
      https://github.com/jakartaee/specification-committee/blob/master/spec_page_template.md
- [x] For a Progress Review, that sufficient progress has been made on a Compatible Implementation and TCK, to ensure that the spec is implementable and testable.
- [x] For a [Release Review](https://www.eclipse.org/projects/handbook/#release-review), a summary that a Compatible Implementation is complete, passes the TCK, and that the TCK includes sufficient coverage of the specification. The TCK users guide MUST include the instructions to run the compatible implementations used to validate the release.
Instructions MAY be by reference.
   - [x] Updated release record
   - [ ] Generated IP Log
   - [ ] Email to PMC
   - [ ] Start release review by emailing EMO 
- [x] The URL of the OSSRH staging repository for the api, javadoc:
      https://repo.eclipse.org/#browse/browse:jsonb-maven2-staging:jakarta%2Fjson%2Fbind%2Fjakarta.json.bind-api%2F3.0.2
- [x] The URL of the staging directory on downloads.eclipse.org for the proposed EFTL TCK binary:
      https://download.eclipse.org/ee4j/jsonb/jakartaee10/promoted/eftl/
- [x] The URL of the compatibility certification request issue:
      N/A service release
- [x] Specification JavaDoc in the wombat/x.y/apidocs directory. 
If desired, an optional second PR can be created to contain just the JavaDoc in the `apidocs` directory.

Note: If any item does not apply, check it and mark N/A below it.
