### PR TITLE
Update Jakarta MVC 3.0 TCK and API version numbers

### DIFF
--- a/mvc/3.0/_index.md
+++ b/mvc/3.0/_index.md
@@ -28,15 +28,15 @@ This release ensures alignment with Jakarta RESTful Web Services 4.0, removes th
 * [Jakarta MVC 3.0 Specification Document](./jakarta-mvc-spec-3.0.pdf) (PDF)
 * [Jakarta MVC 3.0 Specification Document](./jakarta-mvc-spec-3.0.html) (HTML)
 * [Jakarta MVC 3.0 Javadoc](./apidocs)
-* [Jakarta MVC 3.0 TCK](http://download.eclipse.org/jakartaee/mvc/3.0/jakarta-mvc-tck-3.0.0.zip) ([sig](http://download.eclipse.org/jakartaee/mvc/3.0/jakarta-mvc-tck-3.0.0.zip.sig), [sha](http://download.eclipse.org/jakartaee/mvc/3.0/jakarta-mvc-tck-3.0.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta MVC 3.0 TCK](http://download.eclipse.org/jakartaee/mvc/3.0/jakarta-mvc-tck-3.0.1.zip) ([sig](http://download.eclipse.org/jakartaee/mvc/3.0/jakarta-mvc-tck-3.0.1.zip.sig), [sha](http://download.eclipse.org/jakartaee/mvc/3.0/jakarta-mvc-tck-3.0.1.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
   * For all TCK releases, see [download directory](http://download.eclipse.org/jakartaee/mvc/3.0/).
 * Maven coordinates
-  * [jakarta.mvc:jakarta.mvc-api:jar:3.0.0](https://central.sonatype.com/artifact/jakarta.mvc/jakarta.mvc-api/3.0.0/jar)
+  * [jakarta.mvc:jakarta.mvc-api:jar:3.0.1](https://central.sonatype.com/artifact/jakarta.mvc/jakarta.mvc-api/3.0.1/jar)
 * Compatible Implementations used for [ratification](https://www.eclipse.org/projects/efsp/?version=1.2#efsp-ratification).
   * [Eclipse Krazo for Jersey 4.0.0](https://eclipse-ee4j.github.io/krazo/downloads/4.0.0.html)
 
 # Compatible Implementations
-* [Eclipse Krazo for Jersey 4.0.0](https://eclipse-ee4j.github.io/krazo/downloads/4.0.0.html)
+* [Eclipse Krazo for Jersey 4.0.2](https://eclipse-ee4j.github.io/krazo/downloads/4.0.2.html)
 
 ## Ballots
 


### PR DESCRIPTION
TCK to promote: https://download.eclipse.org/ee4j/mvc/staged/3.0/jakarta-mvc-tck-3.0.1.zip



