### PR TITLE
Fix links for NoSQL 1.1 M3 specs

### DIFF
--- a/nosql/1.1/_index.md
+++ b/nosql/1.1/_index.md
@@ -101,8 +101,8 @@ Jakarta NoSQL 1.1 is designed with a **Driver Communication API** that acts as a
 * [Jakarta NoSQL 1.1 Release Record](https://projects.eclipse.org/projects/ee4j.nosql/releases/1.1)
 
 * [Jakarta NoSQL Release Plan](https://projects.eclipse.org/projects/ee4j.nosql/releases/1.1)
-* [Jakarta NoSQL 1.1 M3 Specification Document](./jakarta-nosql-1.1-M3.pdf) (PDF)
-* [Jakarta NoSQL 1.1 M3 Specification Document](./jakarta-nosql-1.1-M3.html) (HTML)
+* [Jakarta NoSQL 1.1 M3 Specification Document](./jakarta-nosql-1.1.0-M3.pdf) (PDF)
+* [Jakarta NoSQL 1.1 M3 Specification Document](./jakarta-nosql-1.1.0-M3.html) (HTML)
 * [Jakarta NoSQL 1.1 M3 Specification Javadoc](./apidocs)
 * Maven coordinates
   * [jakarta-nosql:jakarta.nosql-api:jar:1.1.0-M3](https://central.sonatype.com/artifact/jakarta.nosql/jakarta.nosql-api)


### PR DESCRIPTION
- fixes 404 reported in https://github.com/jakartaee/specifications/pull/912#discussion_r3414512908

I've decided to update links (instead of renaming documents), as files have 1.1.0-M3 embedded inside of them already. 