### PR TITLE
update: yasson certification for jsonb-3.0

### DIFF
--- a/jsonb/3.0/_index.md
+++ b/jsonb/3.0/_index.md
@@ -39,7 +39,7 @@ Jakarta JSON Binding defines a binding framework for converting Java(R) objects 
 
 # Compatible Implementations
 
-* [Eclipse Yasson 3.0.0-RC1](https://github.com/eclipse-ee4j/yasson/releases/tag/3.0.0-RC1)
+* [Eclipse Yasson 3.0.0](https://github.com/eclipse-ee4j/yasson/releases/tag/3.0.0)
 
 # Ballots
 


### PR DESCRIPTION
Fixes: https://github.com/jakartaee/jsonb-api/issues/333
Yasson 3.0.0 CCR was accepted for Jakarta JSON-B 3.0