### PR TITLE
Jakarta JSON Bind 3.0.3 (service release)

### DIFF
--- a/jsonb/3.0/_index.md
+++ b/jsonb/3.0/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Jakarta JSON Binding 3.0"
-date: 2026-05-29
+date: 2026-08-27
 summary: "Release for Jakarta EE 10"
 ---
 Jakarta JSON Binding defines a binding framework for converting Java(R) objects to and from JSON documents.
@@ -30,11 +30,13 @@ Jakarta JSON Binding defines a binding framework for converting Java(R) objects 
 * [Jakarta JSON Binding 3.0.0 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
 * Jakarta JSON Binding 3.0.1 TCK -- Intentionally missing no updates were made to the TCK for service release 3.0.1
 * [Jakarta JSON Binding 3.0.2 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.2.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.2.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.2.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
+* [Jakarta JSON Binding 3.0.3 TCK](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.3.zip) ([sig](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.3.zip.sig), [sha](https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.3.zip.sha256), [pub](https://jakarta.ee/specifications/jakartaee-spec-committee.pub))
   * For all TCK releases, see [download directory](https://download.eclipse.org/jakartaee/jsonb/3.0/)
 * Maven coordinates
   * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.0](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.0/jar)
   * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.1](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.1/jar)
   * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.2](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.2/jar)
+  * [jakarta.json.bind:jakarta.json.bind-api:jar:3.0.3](https://central.sonatype.com/artifact/jakarta.json.bind/jakarta.json.bind-api/3.0.3/jar)
 * [Change Log](./changelog)
 
 # Compatible Implementations

--- a/jsonb/3.0/changelog.md
+++ b/jsonb/3.0/changelog.md
@@ -1,8 +1,13 @@
 ---
 title: "Change Log"
-date: 2026-05-29
+date: 2026-08-27
 summary: "Release for Jakarta EE 10"
 ---
+
+### CHANGES IN THE 3.0.3 RELEASE
+
+* resolves accepted challenges to TCK
+* fixes character encoding assumptions in TCK
 
 ### CHANGES IN THE 3.0.2 RELEASE
 


### PR DESCRIPTION
Fixes https://github.com/jakartaee/jsonb-api/issues/415

Reviewer needs to distribute the Jakarta JSON Bind 3.0.3 TCK

- from: https://download.eclipse.org/ee4j/jsonb/jakartaee10/promoted/eftl/
- to: https://download.eclipse.org/jakartaee/jsonb/3.0/

Draft while we wait for maven central to externalized uploaded artifacts.